### PR TITLE
fix: change from ch to gh link in pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-Relates to Clubhouse Story [ch]()
+[Project Card Link]()
 
 ### Reason for Change
 


### PR DESCRIPTION
### Reason for Change
We were referring to `Clubhouse` as our ticket tracking system in the pull request template, but we're using GitHub projects

### Proposed Changes
Update template to use a placeholder link for github

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


### Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Readme Updated
- [ ] Example project updated
- [ ] Tests added/updated
- [ ] Changelog updated
- [ ] Pubspec version updated
