### PR TITLE
Removing Equatable from Serializable class

### DIFF
--- a/packages/firefuel_core/lib/src/models/document_id/document_id_model.dart
+++ b/packages/firefuel_core/lib/src/models/document_id/document_id_model.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:equatable/equatable.dart';
 import 'package:firefuel_core/src/models/document_id/document_id_serializer.dart';
 import 'package:firefuel_core/src/serializable.dart';
 
@@ -13,7 +14,7 @@ import 'package:firefuel_core/src/serializable.dart';
 /// Potential to throw [FormatException] of type [CannotBeNoLongerThan1500Bytes],
 /// [CannotSolelyConsistOfASingleOrDoublePeriod],
 /// [CannotStartAndEndWithDoubleUnderscore], or [CannotContainForwardSlash].
-class DocumentId extends Serializable {
+class DocumentId extends Serializable with EquatableMixin {
   static const fieldDocId = 'docId';
 
   final String docId;

--- a/packages/firefuel_core/lib/src/serializable.dart
+++ b/packages/firefuel_core/lib/src/serializable.dart
@@ -1,7 +1,3 @@
-import 'package:equatable/equatable.dart';
-
-abstract class Serializable extends Equatable {
-  const Serializable();
-
+abstract class Serializable {
   Map<String, dynamic> toJson();
 }

--- a/packages/firefuel_core/lib/src/serializable.dart
+++ b/packages/firefuel_core/lib/src/serializable.dart
@@ -1,3 +1,5 @@
 abstract class Serializable {
+  const Serializable();
+
   Map<String, dynamic> toJson();
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -70,21 +70,21 @@ packages:
       name: cloud_firestore
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.5.1"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.4.0"
+    version: "5.4.1"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   collection:
     dependency: transitive
     description:
@@ -154,7 +154,7 @@ packages:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -174,7 +174,7 @@ packages:
     description:
       path: "packages/firefuel_core"
       ref: HEAD
-      resolved-ref: "09b8dd382374af028bc241b9f6dd45b030d149b9"
+      resolved-ref: "7ef32b568a101fca53c6e1c65fe1c0304296a316"
       url: "https://github.com/SupposedlySam/firefuel.git"
     source: git
     version: "0.0.1"

--- a/test/src/firefuel_repository_test.dart
+++ b/test/src/firefuel_repository_test.dart
@@ -1,8 +1,8 @@
 import 'package:firefuel/firefuel.dart';
 import '../mocks/mock_collection.dart';
 import '../utils/expected_failure.dart';
-import '../utils/test_user.dart';
 import '../utils/repository_test_util.dart';
+import '../utils/test_user.dart';
 
 void main() {
   final docId = DocumentId('h34jfhg43fiuy3gv4');

--- a/test/src/utils/exceptions_test.dart
+++ b/test/src/utils/exceptions_test.dart
@@ -1,5 +1,6 @@
-import 'package:firefuel/firefuel.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'package:firefuel/firefuel.dart';
 
 void main() {
   group('$MissingValueException', () {

--- a/test/utils/test_user.dart
+++ b/test/utils/test_user.dart
@@ -1,6 +1,7 @@
+import 'package:equatable/equatable.dart';
 import 'package:firefuel/firefuel.dart';
 
-class TestUser extends Serializable {
+class TestUser extends Serializable with EquatableMixin {
   static const String fieldName = 'name';
 
   TestUser(this.name, [this.docId]);

--- a/test/utils/test_user.dart
+++ b/test/utils/test_user.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+
 import 'package:firefuel/firefuel.dart';
 
 class TestUser extends Serializable with EquatableMixin {


### PR DESCRIPTION
[Project Card Link](https://github.com/SupposedlySam/firefuel/projects/1#card-67891879)

### Reason for Change
For classes that already extended `Equatable` (such as freezed classes)
Equatable required to override the prop method, which may be unnecessary for some. Removing equatable allows (freezed) classes to only require the `toJson` method

### Proposed Changes
Removed `Equatable` from `Serializable` class
Added `Equatable` to the `DocumentId` and `TestUser` classes

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


### Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Readme Updated
- [ ] Example project updated
- [ ] Tests added/updated
- [ ] Changelog updated
- [ ] Pubspec version updated
