### PR TITLE
feat: Create CollectionRef and Stream w/ (From|To)Firestore Methods

### DIFF
--- a/lib/src/firefuel_collection.dart
+++ b/lib/src/firefuel_collection.dart
@@ -8,22 +8,24 @@ import 'package:firefuel/src/collection.dart';
 abstract class FirefuelCollection<T extends Serializable>
     implements Collection<T> {
   final String collectionName;
+  final FirebaseFirestore firestoreInstance;
 
-  FirefuelCollection(this.collectionName);
+  const FirefuelCollection(
+    this.collectionName, {
+    required this.firestoreInstance,
+  });
 
   @override
   Future<DocumentId> create({required T value, DocumentId? docId}) async {
     final documentRef = docId != null
         ? (collectionRef.doc(docId.docId)..set(value))
         : await collectionRef.add(value);
-
     return DocumentId(documentRef.id);
   }
 
   @override
   Future<Null> delete(DocumentId docId) async {
     await collectionRef.doc(docId.docId).delete();
-
     return null;
   }
 

--- a/lib/src/firefuel_collection.dart
+++ b/lib/src/firefuel_collection.dart
@@ -39,12 +39,14 @@ abstract class FirefuelCollection<T extends Serializable>
     final documentRef = docId != null
         ? (collectionRef.doc(docId.docId)..set(value))
         : await collectionRef.add(value);
+
     return DocumentId(documentRef.id);
   }
 
   @override
   Future<Null> delete(DocumentId docId) async {
     await collectionRef.doc(docId.docId).delete();
+
     return null;
   }
 

--- a/lib/src/firefuel_collection.dart
+++ b/lib/src/firefuel_collection.dart
@@ -15,6 +15,25 @@ abstract class FirefuelCollection<T extends Serializable>
     required this.firestoreInstance,
   });
 
+  /// Converts a [DocumentSnapshot] to a [T]
+  T fromFirestore(
+    DocumentSnapshot<Map<String, dynamic>> document,
+    SnapshotOptions? options,
+  );
+
+  /// Converts a [T] to a [Map<String, dynamic>] to upload to Firestore.
+  Map<String, Object?> toFirestore(
+    T? value,
+    SetOptions? options,
+  );
+
+  @override
+  CollectionReference<T?> get collectionRef =>
+      untypedCollectionRef(firestoreInstance).withConverter(
+        fromFirestore: fromFirestore,
+        toFirestore: toFirestore,
+      );
+
   @override
   Future<DocumentId> create({required T value, DocumentId? docId}) async {
     final documentRef = docId != null

--- a/lib/src/firefuel_collection.dart
+++ b/lib/src/firefuel_collection.dart
@@ -7,32 +7,25 @@ import 'package:firefuel/src/collection.dart';
 
 abstract class FirefuelCollection<T extends Serializable>
     implements Collection<T> {
-  final String collectionName;
-  final FirebaseFirestore firestoreInstance;
+  final String collectionPath;
+  final FirebaseFirestore firestore;
 
-  const FirefuelCollection(
-    this.collectionName, {
-    required this.firestoreInstance,
-  });
-
-  /// Converts a [DocumentSnapshot] to a [T]
-  T fromFirestore(
-    DocumentSnapshot<Map<String, dynamic>> document,
-    SnapshotOptions? options,
-  );
-
-  /// Converts a [T] to a [Map<String, Object?>] to upload to Firestore.
-  Map<String, Object?> toFirestore(
-    T? value,
-    SetOptions? options,
-  );
+  const FirefuelCollection(this.collectionPath, {required this.firestore});
 
   @override
-  CollectionReference<T?> get collectionRef =>
-      untypedCollectionRef(firestoreInstance).withConverter(
-        fromFirestore: fromFirestore,
-        toFirestore: toFirestore,
-      );
+  CollectionReference<T?> get collectionRef {
+    return untypedCollectionRef.withConverter(
+      fromFirestore: fromFirestore,
+      toFirestore: toFirestore,
+    );
+  }
+
+  @override
+  Stream<List<T>> get stream => listenAll(collectionRef);
+
+  CollectionReference<Map<String, dynamic>> get untypedCollectionRef {
+    return firestore.collection(collectionPath);
+  }
 
   @override
   Future<DocumentId> create({required T value, DocumentId? docId}) async {
@@ -49,6 +42,12 @@ abstract class FirefuelCollection<T extends Serializable>
 
     return null;
   }
+
+  /// Converts a [DocumentSnapshot] to a [T?]
+  T? fromFirestore(
+    DocumentSnapshot<Map<String, dynamic>> snapshot,
+    SnapshotOptions? options,
+  );
 
   Future<T> getOrCreate({
     required DocumentId docId,
@@ -97,11 +96,11 @@ abstract class FirefuelCollection<T extends Serializable>
     return snapshots.map((documentSnapshot) => documentSnapshot.data());
   }
 
-  CollectionReference<Map<String, dynamic>> untypedCollectionRef(
-    FirebaseFirestore instance,
-  ) {
-    return instance.collection(collectionName);
-  }
+  /// Converts a [T?] to a [Map<String, Object?>] to upload to Firestore.
+  Map<String, Object?> toFirestore(
+    T? model,
+    SetOptions? options,
+  );
 
   @override
   Future<Null> update({

--- a/lib/src/firefuel_collection.dart
+++ b/lib/src/firefuel_collection.dart
@@ -21,7 +21,7 @@ abstract class FirefuelCollection<T extends Serializable>
     SnapshotOptions? options,
   );
 
-  /// Converts a [T] to a [Map<String, dynamic>] to upload to Firestore.
+  /// Converts a [T] to a [Map<String, Object?>] to upload to Firestore.
   Map<String, Object?> toFirestore(
     T? value,
     SetOptions? options,

--- a/test/src/firefuel_collection_test.dart
+++ b/test/src/firefuel_collection_test.dart
@@ -270,22 +270,20 @@ void main() {
 }
 
 class TestCollection extends FirefuelCollection<TestUser> {
-  TestCollection(this.instance) : super(_testUsersCollectionName);
-
-  final FirebaseFirestore instance;
-
-  @override
-  CollectionReference<TestUser?> get collectionRef =>
-      super.untypedCollectionRef(instance).withConverter(
-            fromFirestore: (snapshot, _) {
-              final data = snapshot.data();
-              return data == null
-                  ? null
-                  : TestUser.fromJson(snapshot.data()!, snapshot.id);
-            },
-            toFirestore: (model, _) => model?.toJson() ?? <String, Object?>{},
-          );
+  TestCollection(FirebaseFirestore firestore)
+      : super(_testUsersCollectionName, firestore: firestore);
 
   @override
-  Stream<List<TestUser>> get stream => listenAll(collectionRef);
+  TestUser? fromFirestore(DocumentSnapshot<Map<String, dynamic>> snapshot,
+      SnapshotOptions? options) {
+    final data = snapshot.data();
+    return data == null
+        ? null
+        : TestUser.fromJson(snapshot.data()!, snapshot.id);
+  }
+
+  @override
+  Map<String, Object?> toFirestore(TestUser? model, SetOptions? options) {
+    return model?.toJson() ?? <String, Object?>{};
+  }
 }


### PR DESCRIPTION
[Project Card Link: firefuelInstance](https://github.com/SupposedlySam/firefuel/projects/1#card-67968782)
[Project Card Link: collectionRef](https://github.com/SupposedlySam/firefuel/projects/1#card-67968759)

### Reason for Change
Simplify method to retrieve `collectionRef`.

### Proposed Changes
Require the Firestore instance as constructor to use within the the `FirefuelCollection`.
Create `fromFirestore` and `toFirestore` that will be used as the methods to create the `collectionRef` getter.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


### Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Readme Updated
- [ ] Example project updated
- [ ] Tests added/updated
- [ ] Changelog updated
- [ ] Pubspec version updated
