### PR TITLE
refactor!: renamed getOrCreate to readOrCreate

### DIFF
--- a/lib/src/collection.dart
+++ b/lib/src/collection.dart
@@ -40,7 +40,7 @@ abstract class Collection<T extends Serializable> {
   ///
   /// If the documentId returns a snapshot that does not exist, or `data()`
   /// returns `null`, create a new document with the [docId] provided.
-  Future<T> getOrCreate({
+  Future<T> readOrCreate({
     required DocumentId docId,
     required T createValue,
   });

--- a/lib/src/firefuel_collection.dart
+++ b/lib/src/firefuel_collection.dart
@@ -49,7 +49,7 @@ abstract class FirefuelCollection<T extends Serializable>
     SnapshotOptions? options,
   );
 
-  Future<T> getOrCreate({
+  Future<T> readOrCreate({
     required DocumentId docId,
     required T createValue,
   }) async {

--- a/test/src/firefuel_collection_test.dart
+++ b/test/src/firefuel_collection_test.dart
@@ -81,11 +81,11 @@ void main() {
     });
   });
 
-  group('#getOrCreate', () {
+  group('#readOrCreate', () {
     final documentId = DocumentId('testName');
 
     test('should create the doc when it does not exist', () async {
-      final result = await testCollection.getOrCreate(
+      final result = await testCollection.readOrCreate(
           docId: documentId, createValue: defaultUser);
 
       expect(result, defaultUser);
@@ -94,7 +94,7 @@ void main() {
     test('should get doc when it exists', () async {
       final docId = await testCollection.create(value: defaultUser);
 
-      final testUser = await testCollection.getOrCreate(
+      final testUser = await testCollection.readOrCreate(
           docId: docId, createValue: defaultUser);
 
       expect(docId.docId, testUser.docId);


### PR DESCRIPTION
[Project Card Link](https://github.com/SupposedlySam/firefuel/projects/1#card-67877432)

### Reason for Change
- To follow CRUD's naming convention instead of Firestore's convention 

### Proposed Changes
- Rename `getOrCreate` to `readOrCreate`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


### Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Readme Updated
- [ ] Example project updated
- [x] Tests added/updated
- [ ] Changelog updated
- [ ] Pubspec version updated
