### PR TITLE
refactor!: drop collection prefix

### DIFF
--- a/packages/firefuel/lib/src/collection.dart
+++ b/packages/firefuel/lib/src/collection.dart
@@ -6,7 +6,7 @@ import 'package:firefuel_core/firefuel_core.dart';
 abstract class Collection<T extends Serializable> {
   const Collection();
 
-  CollectionReference<T?> get collectionRef;
+  CollectionReference<T?> get ref;
 
   /// Exposes the Typed Stream from the Collection
   ///
@@ -15,14 +15,14 @@ abstract class Collection<T extends Serializable> {
   ///### Example
   ///#### Stream a top level collection
   /// ```
-  /// Stream<List<YourType>> get stream => listen(collectionRef);
+  /// Stream<List<YourType>> get stream => listen(ref);
   /// ```
   ///
   /// #### Stream a subcollection
   ///
   /// ```
-  /// Stream<List<T>> streamSubcollection<T>(CollectionReference<T> collectionReference) {
-  ///   return listen<T>(collectionReference);
+  /// Stream<List<T>> streamSubcollection<T>(CollectionReference<T> reference) {
+  ///   return listen<T>(reference);
   /// }
   /// ```
   Stream<List<T>> get stream;
@@ -45,7 +45,7 @@ abstract class Collection<T extends Serializable> {
   ///
   /// See: StreamBuilder
   Stream<T?> listen<T>(
-    CollectionReference<T> collectionRef,
+    CollectionReference<T> ref,
     DocumentId docId,
   );
 
@@ -54,7 +54,7 @@ abstract class Collection<T extends Serializable> {
   /// Refreshes automatically when new data is added to the collection
   ///
   /// See: StreamBuilder
-  Stream<List<T>> listenAll<T>(CollectionReference<T> collectionRef);
+  Stream<List<T>> listenAll<T>(CollectionReference<T> ref);
 
   /// Gets a single document from the collection
   ///

--- a/packages/firefuel/lib/src/firefuel_collection.dart
+++ b/packages/firefuel/lib/src/firefuel_collection.dart
@@ -15,7 +15,7 @@ abstract class FirefuelCollection<T extends Serializable>
   final firestore = Firefuel.firestore;
 
   @override
-  CollectionReference<T?> get collectionRef {
+  CollectionReference<T?> get ref {
     return untypedCollectionRef.withConverter(
       fromFirestore: fromFirestore,
       toFirestore: toFirestore,
@@ -23,7 +23,7 @@ abstract class FirefuelCollection<T extends Serializable>
   }
 
   @override
-  Stream<List<T>> get stream => listenAll(collectionRef);
+  Stream<List<T>> get stream => listenAll(ref);
 
   CollectionReference<Map<String, dynamic>> get untypedCollectionRef {
     return firestore.collection(collectionPath);
@@ -31,7 +31,7 @@ abstract class FirefuelCollection<T extends Serializable>
 
   @override
   Future<DocumentId> create(T value) async {
-    final documentRef = await collectionRef.add(value);
+    final documentRef = await ref.add(value);
 
     return DocumentId(documentRef.id);
   }
@@ -41,14 +41,14 @@ abstract class FirefuelCollection<T extends Serializable>
     required T value,
     required DocumentId docId,
   }) async {
-    await collectionRef.doc(docId.docId).set(value);
+    await ref.doc(docId.docId).set(value);
 
     return null;
   }
 
   @override
   Future<Null> delete(DocumentId docId) async {
-    await collectionRef.doc(docId.docId).delete();
+    await ref.doc(docId.docId).delete();
 
     return null;
   }
@@ -61,29 +61,29 @@ abstract class FirefuelCollection<T extends Serializable>
 
   @override
   Stream<T?> listen<T>(
-    CollectionReference<T?> collectionRef,
+    CollectionReference<T?> ref,
     DocumentId docId,
   ) {
-    return collectionRef.doc(docId.docId).snapshots().map(
+    return ref.doc(docId.docId).snapshots().map(
           (snapshot) => snapshot.data(),
         );
   }
 
   @override
-  Stream<List<T>> listenAll<T>(CollectionReference<T?> collectionRef) {
-    return collectionRef.snapshots().map(
+  Stream<List<T>> listenAll<T>(CollectionReference<T?> ref) {
+    return ref.snapshots().map(
           (collection) =>
               collection.docs.map((doc) => doc.data()).whereType<T>().toList(),
         );
   }
 
   Future<T?> read(DocumentId docId) async {
-    final snapshot = await collectionRef.doc(docId.docId).get();
+    final snapshot = await ref.doc(docId.docId).get();
     return snapshot.data();
   }
 
   Stream<T?> readAsStream(DocumentId docId) {
-    final snapshots = collectionRef.doc(docId.docId).snapshots();
+    final snapshots = ref.doc(docId.docId).snapshots();
 
     return snapshots.map((documentSnapshot) => documentSnapshot.data());
   }
@@ -112,7 +112,7 @@ abstract class FirefuelCollection<T extends Serializable>
 
     if (existingDoc == null) return null;
 
-    await collectionRef.doc(docId.docId).set(value);
+    await ref.doc(docId.docId).set(value);
 
     return null;
   }
@@ -144,7 +144,7 @@ abstract class FirefuelCollection<T extends Serializable>
     required DocumentId docId,
     required T value,
   }) async {
-    await collectionRef.doc(docId.docId).update(value.toJson());
+    await ref.doc(docId.docId).update(value.toJson());
 
     return null;
   }
@@ -154,7 +154,7 @@ abstract class FirefuelCollection<T extends Serializable>
     required DocumentId docId,
     required T value,
   }) async {
-    await collectionRef.doc(docId.docId).set(value, SetOptions(merge: true));
+    await ref.doc(docId.docId).set(value, SetOptions(merge: true));
 
     return null;
   }

--- a/packages/firefuel/lib/src/firefuel_collection.dart
+++ b/packages/firefuel/lib/src/firefuel_collection.dart
@@ -8,9 +8,9 @@ import 'package:firefuel/src/firefuel.dart';
 
 abstract class FirefuelCollection<T extends Serializable>
     implements Collection<T> {
-  final String collectionPath;
+  final String path;
 
-  FirefuelCollection(this.collectionPath);
+  FirefuelCollection(this.path);
 
   final firestore = Firefuel.firestore;
 
@@ -26,7 +26,7 @@ abstract class FirefuelCollection<T extends Serializable>
   Stream<List<T>> get stream => listenAll(ref);
 
   CollectionReference<Map<String, dynamic>> get untypedCollectionRef {
-    return firestore.collection(collectionPath);
+    return firestore.collection(path);
   }
 
   @override

--- a/packages/firefuel/lib/src/firefuel_collection.dart
+++ b/packages/firefuel/lib/src/firefuel_collection.dart
@@ -16,7 +16,7 @@ abstract class FirefuelCollection<T extends Serializable>
 
   @override
   CollectionReference<T?> get ref {
-    return untypedCollectionRef.withConverter(
+    return untypedRef.withConverter(
       fromFirestore: fromFirestore,
       toFirestore: toFirestore,
     );
@@ -25,7 +25,7 @@ abstract class FirefuelCollection<T extends Serializable>
   @override
   Stream<List<T>> get stream => listenAll(ref);
 
-  CollectionReference<Map<String, dynamic>> get untypedCollectionRef {
+  CollectionReference<Map<String, dynamic>> get untypedRef {
     return firestore.collection(path);
   }
 
@@ -128,7 +128,7 @@ abstract class FirefuelCollection<T extends Serializable>
     final replacement = value.toJson()
       ..removeWhere((key, _) => !paths.contains(FieldPath.fromString(key)));
 
-    await untypedCollectionRef.doc(docId.docId).update(replacement);
+    await untypedRef.doc(docId.docId).update(replacement);
 
     return null;
   }

--- a/packages/firefuel/test/src/firefuel_collection_test.dart
+++ b/packages/firefuel/test/src/firefuel_collection_test.dart
@@ -107,7 +107,7 @@ void main() {
     setUp(() async {
       docId = await testCollection.create(defaultUser);
 
-      stream = testCollection.listen(testCollection.collectionRef, docId);
+      stream = testCollection.listen(testCollection.ref, docId);
     });
 
     test('should output new value when doc updates', () async {
@@ -142,7 +142,7 @@ void main() {
       docId = await testCollection.create(defaultUser);
       await testCollection.create(newUser1);
 
-      stream = testCollection.listenAll(testCollection.collectionRef);
+      stream = testCollection.listenAll(testCollection.ref);
     });
 
     test('should update when an item is added', () async {


### PR DESCRIPTION
[Project Card Link](https://github.com/SupposedlySam/firefuel/projects/1#card-68316758)
Resolves Issue #15 

### Reason for Change
`collectionRef` and `collectionPath` were redundant since they were inside of the `Collection` class

### Proposed Changes
Rename `collectionRef` to `ref` and `collectionPath` to `path`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


### Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Readme Updated
- [ ] Example project updated
- [ ] Tests added/updated
- [ ] Changelog updated
- [ ] Pubspec version updated
