### PR TITLE
feat!: Sync Methods Between Collection and Repository

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,5 @@
 include: package:very_good_analysis/analysis_options.2.3.0.yaml
+
+analyzer:
+  enable-experiment:
+    - variance

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,1 @@
 include: package:very_good_analysis/analysis_options.2.3.0.yaml
-
-analyzer:
-  enable-experiment:
-    - variance

--- a/packages/firefuel/lib/firefuel.dart
+++ b/packages/firefuel/lib/firefuel.dart
@@ -6,6 +6,7 @@ export 'package:firefuel/src/firefuel_collection.dart';
 export 'package:firefuel/src/firefuel_failure.dart';
 export 'package:firefuel/src/firefuel_fetch_mixin.dart';
 export 'package:firefuel/src/firefuel_repository.dart';
+export 'package:firefuel/src/rules.dart';
 export 'package:firefuel/src/utils/either_extensions.dart';
 export 'package:firefuel/src/utils/exceptions.dart';
 export 'package:firefuel_core/firefuel_core.dart';

--- a/packages/firefuel/lib/src/collection.dart
+++ b/packages/firefuel/lib/src/collection.dart
@@ -3,7 +3,7 @@ import 'package:firefuel_core/firefuel_core.dart';
 
 import 'package:firefuel/src/rules.dart';
 
-abstract class Collection<inout T extends Serializable>
+abstract class Collection<T extends Serializable>
     implements
         CollectionRead<List<T>, T>,
         DocCreate<DocumentId, T>,
@@ -17,4 +17,4 @@ abstract class Collection<inout T extends Serializable>
   CollectionReference<T?> get ref;
 
   Stream<List<T>> get stream;
-        }
+}

--- a/packages/firefuel/lib/src/collection.dart
+++ b/packages/firefuel/lib/src/collection.dart
@@ -1,112 +1,20 @@
-import 'dart:async';
-
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firefuel_core/firefuel_core.dart';
 
-abstract class Collection<T extends Serializable> {
+import 'package:firefuel/src/rules.dart';
+
+abstract class Collection<inout T extends Serializable>
+    implements
+        CollectionRead<List<T>, T>,
+        DocCreate<DocumentId, T>,
+        DocCreateIfNotExist<T, T>,
+        DocDelete<Null>,
+        DocRead<T?>,
+        DocReplace<Null, T>,
+        DocUpdate<Null, T> {
   const Collection();
 
   CollectionReference<T?> get ref;
 
-  /// Exposes the Typed Stream from the Collection
-  ///
-  /// Use the [listen] method to implement this getter
-  ///
-  ///### Example
-  ///#### Stream a top level collection
-  /// ```
-  /// Stream<List<YourType>> get stream => listen(ref);
-  /// ```
-  ///
-  /// #### Stream a subcollection
-  ///
-  /// ```
-  /// Stream<List<T>> streamSubcollection<T>(CollectionReference<T> reference) {
-  ///   return listen<T>(reference);
-  /// }
-  /// ```
   Stream<List<T>> get stream;
-
-  /// Create a new document with an auto-generated [DocumentId]
-  Future<DocumentId> create(T value);
-
-  /// Create a new document with the provided [docId]
-  Future<Null> createById({
-    required T value,
-    required DocumentId docId,
-  });
-
-  /// Deletes the current document from the collection.
-  Future<Null> delete(DocumentId docId);
-
-  /// Get a document from the collection
-  ///
-  /// Refreshes automatically when new data is added to the document
-  ///
-  /// See: StreamBuilder
-  Stream<T?> listen<T>(
-    CollectionReference<T> ref,
-    DocumentId docId,
-  );
-
-  /// Get a list of all documents from the collection as a list
-  ///
-  /// Refreshes automatically when new data is added to the collection
-  ///
-  /// See: StreamBuilder
-  Stream<List<T>> listenAll<T>(CollectionReference<T> ref);
-
-  /// Gets a single document from the collection
-  ///
-  /// Does NOT refresh automatically
-  Future<T?> read(DocumentId docId);
-
-  /// Gets a stream of the document requested
-  Stream<T?> readAsStream(DocumentId docId);
-
-  /// Get the document by id, or create a new one
-  ///
-  /// If the documentId returns a snapshot that does not exist, or `data()`
-  /// returns `null`, create a new document with the [docId] provided.
-  Future<T> readOrCreate({
-    required DocumentId docId,
-    required T createValue,
-  });
-
-  /// Replaces the document at [docId] with [value].
-  ///
-  /// If no document exists yet, the replace will fail.
-  ///
-  /// *Requires 1 read of doc to perform replace*
-  Future<Null> replace({required DocumentId docId, required T value});
-
-  /// Replaces the fields of the document at [docId] with the matching
-  /// [fieldPaths] from [value]
-  ///
-  /// Converts all [fieldPaths] into [FieldPath] objects to compare against
-  ///
-  /// If no document exists yet, the update will fail silently.
-  Future<Null> replaceFields({
-    required DocumentId docId,
-    required T value,
-    required List<String> fieldPaths,
-  });
-
-  /// Updates data on the document. Data will be merged with any existing
-  /// document data.
-  ///
-  /// If no document exists yet, the update will fail silently.
-  Future<Null> update({
-    required DocumentId docId,
-    required T value,
-  });
-
-  /// Updates data on the document if it exists. Data will be merged with
-  /// any existing document data.
-  ///
-  /// If no document exists, a new document will be created
-  Future<Null> updateOrCreate({
-    required DocumentId docId,
-    required T value,
-  });
-}
+        }

--- a/packages/firefuel/lib/src/firefuel_collection.dart
+++ b/packages/firefuel/lib/src/firefuel_collection.dart
@@ -153,6 +153,6 @@ abstract class FirefuelCollection<T extends Serializable>
   }) async {
     await ref.doc(docId.docId).set(value, SetOptions(merge: true));
 
-    return (await read(docId))!;
+    return value;
   }
 }

--- a/packages/firefuel/lib/src/firefuel_collection.dart
+++ b/packages/firefuel/lib/src/firefuel_collection.dart
@@ -6,7 +6,7 @@ import 'package:firefuel_core/firefuel_core.dart';
 import 'package:firefuel/src/collection.dart';
 import 'package:firefuel/src/firefuel.dart';
 
-abstract class FirefuelCollection<T extends Serializable>
+abstract class FirefuelCollection<inout T extends Serializable>
     implements Collection<T> {
   final String path;
 
@@ -37,13 +37,13 @@ abstract class FirefuelCollection<T extends Serializable>
   }
 
   @override
-  Future<Null> createById({
+  Future<DocumentId> createById({
     required T value,
     required DocumentId docId,
   }) async {
     await ref.doc(docId.docId).set(value);
 
-    return null;
+    return docId;
   }
 
   @override
@@ -60,17 +60,14 @@ abstract class FirefuelCollection<T extends Serializable>
   );
 
   @override
-  Stream<T?> listen<T>(
-    CollectionReference<T?> ref,
-    DocumentId docId,
-  ) {
+  Stream<T?> listen(DocumentId docId) {
     return ref.doc(docId.docId).snapshots().map(
           (snapshot) => snapshot.data(),
         );
   }
 
   @override
-  Stream<List<T>> listenAll<T>(CollectionReference<T?> ref) {
+  Stream<List<T>> listenAll(CollectionReference<T?> ref) {
     return ref.snapshots().map(
           (collection) =>
               collection.docs.map((doc) => doc.data()).whereType<T>().toList(),
@@ -150,12 +147,12 @@ abstract class FirefuelCollection<T extends Serializable>
   }
 
   @override
-  Future<Null> updateOrCreate({
+  Future<T> updateOrCreate({
     required DocumentId docId,
     required T value,
   }) async {
     await ref.doc(docId.docId).set(value, SetOptions(merge: true));
 
-    return null;
+    return (await read(docId))!;
   }
 }

--- a/packages/firefuel/lib/src/firefuel_collection.dart
+++ b/packages/firefuel/lib/src/firefuel_collection.dart
@@ -6,7 +6,7 @@ import 'package:firefuel_core/firefuel_core.dart';
 import 'package:firefuel/src/collection.dart';
 import 'package:firefuel/src/firefuel.dart';
 
-abstract class FirefuelCollection<inout T extends Serializable>
+abstract class FirefuelCollection<T extends Serializable>
     implements Collection<T> {
   final String path;
 

--- a/packages/firefuel/lib/src/firefuel_collection.dart
+++ b/packages/firefuel/lib/src/firefuel_collection.dart
@@ -23,7 +23,7 @@ abstract class FirefuelCollection<T extends Serializable>
   }
 
   @override
-  Stream<List<T>> get stream => listenAll(ref);
+  Stream<List<T>> get stream => listenAll();
 
   CollectionReference<Map<String, dynamic>> get untypedRef {
     return firestore.collection(path);
@@ -67,7 +67,7 @@ abstract class FirefuelCollection<T extends Serializable>
   }
 
   @override
-  Stream<List<T>> listenAll(CollectionReference<T?> ref) {
+  Stream<List<T>> listenAll() {
     return ref.snapshots().map(
           (collection) =>
               collection.docs.map((doc) => doc.data()).whereType<T>().toList(),

--- a/packages/firefuel/lib/src/firefuel_repository.dart
+++ b/packages/firefuel/lib/src/firefuel_repository.dart
@@ -1,4 +1,3 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:dartz/dartz.dart';
 import 'package:firefuel_core/firefuel_core.dart';
 
@@ -38,8 +37,8 @@ abstract class FirefuelRepository<T extends Serializable>
   }
 
   @override
-  Stream<Either<Failure, List<T>>> listenAll(CollectionReference<T> ref) {
-    return guardStream(() => _collection.listenAll(ref));
+  Stream<Either<Failure, List<T>>> listenAll() {
+    return guardStream(() => _collection.listenAll());
   }
 
   @override

--- a/packages/firefuel/lib/src/firefuel_repository.dart
+++ b/packages/firefuel/lib/src/firefuel_repository.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:dartz/dartz.dart';
 import 'package:firefuel_core/firefuel_core.dart';
 
@@ -5,7 +6,7 @@ import 'package:firefuel/firefuel.dart';
 import 'package:firefuel/src/collection.dart';
 import 'package:firefuel/src/repository.dart';
 
-abstract class FirefuelRepository<T extends Serializable>
+abstract class FirefuelRepository<inout T extends Serializable>
     with FirefuelFetchMixin
     implements Repository<T> {
   final Collection<T> _collection;
@@ -14,11 +15,31 @@ abstract class FirefuelRepository<T extends Serializable>
       : _collection = collection;
 
   @override
-  Future<Either<Failure, DocumentId>> create({
-    required T value,
-    DocumentId? docId,
-  }) {
+  Future<Either<Failure, DocumentId>> create(T value) {
     return guard(() => _collection.create(value));
+  }
+
+  @override
+  Future<Either<Failure, DocumentId>> createById({
+    required T value,
+    required DocumentId docId,
+  }) {
+    return guard(() => _collection.createById(docId: docId, value: value));
+  }
+
+  @override
+  Future<Either<Failure, Null>> delete(DocumentId docId) {
+    return guard(() => _collection.delete(docId));
+  }
+
+  @override
+  Stream<Either<Failure, T?>> listen(DocumentId docId) {
+    return guardStream(() => _collection.listen(docId));
+  }
+
+  @override
+  Stream<Either<Failure, List<T>>> listenAll(CollectionReference<T> ref) {
+    return guardStream(() => _collection.listenAll(ref));
   }
 
   @override
@@ -27,8 +48,18 @@ abstract class FirefuelRepository<T extends Serializable>
   }
 
   @override
-  Stream<Either<Failure, T?>> readAsStream(DocumentId docId) {
-    return guardStream(() => _collection.readAsStream(docId));
+  Future<Either<Failure, T>> readOrCreate({required DocumentId docId, required T createValue}) {
+    return guard(() => _collection.readOrCreate(docId: docId, createValue: createValue));
+  }
+
+  @override
+  Future<Either<Failure, Null>> replace({required DocumentId docId, required T value}) {
+    return guard(() => _collection.replace(docId: docId, value: value));
+  }
+
+  @override
+  Future<Either<Failure, Null>> replaceFields({required DocumentId docId, required T value, required List<String> fieldPaths}) {
+    return guard(() => _collection.replaceFields(docId: docId, value: value, fieldPaths: fieldPaths));
   }
 
   @override
@@ -45,7 +76,7 @@ abstract class FirefuelRepository<T extends Serializable>
   }
 
   @override
-  Future<Either<Failure, Null>> delete(DocumentId docId) {
-    return guard(() => _collection.delete(docId));
+  Future<Either<Failure, T>> updateOrCreate({required DocumentId docId, required T value}) {
+    return guard(() => _collection.updateOrCreate(docId: docId, value: value));
   }
 }

--- a/packages/firefuel/lib/src/firefuel_repository.dart
+++ b/packages/firefuel/lib/src/firefuel_repository.dart
@@ -6,7 +6,7 @@ import 'package:firefuel/firefuel.dart';
 import 'package:firefuel/src/collection.dart';
 import 'package:firefuel/src/repository.dart';
 
-abstract class FirefuelRepository<inout T extends Serializable>
+abstract class FirefuelRepository<T extends Serializable>
     with FirefuelFetchMixin
     implements Repository<T> {
   final Collection<T> _collection;
@@ -48,18 +48,25 @@ abstract class FirefuelRepository<inout T extends Serializable>
   }
 
   @override
-  Future<Either<Failure, T>> readOrCreate({required DocumentId docId, required T createValue}) {
-    return guard(() => _collection.readOrCreate(docId: docId, createValue: createValue));
+  Future<Either<Failure, T>> readOrCreate(
+      {required DocumentId docId, required T createValue}) {
+    return guard(
+        () => _collection.readOrCreate(docId: docId, createValue: createValue));
   }
 
   @override
-  Future<Either<Failure, Null>> replace({required DocumentId docId, required T value}) {
+  Future<Either<Failure, Null>> replace(
+      {required DocumentId docId, required T value}) {
     return guard(() => _collection.replace(docId: docId, value: value));
   }
 
   @override
-  Future<Either<Failure, Null>> replaceFields({required DocumentId docId, required T value, required List<String> fieldPaths}) {
-    return guard(() => _collection.replaceFields(docId: docId, value: value, fieldPaths: fieldPaths));
+  Future<Either<Failure, Null>> replaceFields(
+      {required DocumentId docId,
+      required T value,
+      required List<String> fieldPaths}) {
+    return guard(() => _collection.replaceFields(
+        docId: docId, value: value, fieldPaths: fieldPaths));
   }
 
   @override
@@ -76,7 +83,8 @@ abstract class FirefuelRepository<inout T extends Serializable>
   }
 
   @override
-  Future<Either<Failure, T>> updateOrCreate({required DocumentId docId, required T value}) {
+  Future<Either<Failure, T>> updateOrCreate(
+      {required DocumentId docId, required T value}) {
     return guard(() => _collection.updateOrCreate(docId: docId, value: value));
   }
 }

--- a/packages/firefuel/lib/src/firefuel_repository.dart
+++ b/packages/firefuel/lib/src/firefuel_repository.dart
@@ -48,25 +48,39 @@ abstract class FirefuelRepository<T extends Serializable>
   }
 
   @override
-  Future<Either<Failure, T>> readOrCreate(
-      {required DocumentId docId, required T createValue}) {
-    return guard(
-        () => _collection.readOrCreate(docId: docId, createValue: createValue));
+  Future<Either<Failure, T>> readOrCreate({
+    required DocumentId docId,
+    required T createValue,
+  }) {
+    return guard(() {
+      return _collection.readOrCreate(
+        docId: docId,
+        createValue: createValue,
+      );
+    });
   }
 
   @override
-  Future<Either<Failure, Null>> replace(
-      {required DocumentId docId, required T value}) {
+  Future<Either<Failure, Null>> replace({
+    required DocumentId docId,
+    required T value,
+  }) {
     return guard(() => _collection.replace(docId: docId, value: value));
   }
 
   @override
-  Future<Either<Failure, Null>> replaceFields(
-      {required DocumentId docId,
-      required T value,
-      required List<String> fieldPaths}) {
-    return guard(() => _collection.replaceFields(
-        docId: docId, value: value, fieldPaths: fieldPaths));
+  Future<Either<Failure, Null>> replaceFields({
+    required DocumentId docId,
+    required T value,
+    required List<String> fieldPaths,
+  }) {
+    return guard(() {
+      return _collection.replaceFields(
+        docId: docId,
+        value: value,
+        fieldPaths: fieldPaths,
+      );
+    });
   }
 
   @override
@@ -83,8 +97,10 @@ abstract class FirefuelRepository<T extends Serializable>
   }
 
   @override
-  Future<Either<Failure, T>> updateOrCreate(
-      {required DocumentId docId, required T value}) {
+  Future<Either<Failure, T>> updateOrCreate({
+    required DocumentId docId,
+    required T value,
+  }) {
     return guard(() => _collection.updateOrCreate(docId: docId, value: value));
   }
 }

--- a/packages/firefuel/lib/src/repository.dart
+++ b/packages/firefuel/lib/src/repository.dart
@@ -1,22 +1,14 @@
 import 'package:dartz/dartz.dart';
 import 'package:firefuel_core/firefuel_core.dart';
 
-import 'package:firefuel/firefuel.dart';
+import 'package:firefuel/src/rules.dart';
 
-abstract class Repository<T> {
-  Future<Either<Failure, DocumentId>> create({
-    required T value,
-    DocumentId docId,
-  });
-
-  Future<Either<Failure, T?>> read(DocumentId docId);
-
-  Stream<Either<Failure, T?>> readAsStream(DocumentId docId);
-
-  Future<Either<Failure, Null>> update({
-    required DocumentId docId,
-    required T value,
-  });
-
-  Future<Either<Failure, Null>> delete(DocumentId docId);
-}
+abstract class Repository<inout T extends Serializable>
+    implements
+        CollectionRead<Either<Failure, List<T>>, T>,
+        DocCreate<Either<Failure, DocumentId>, T>,
+        DocCreateIfNotExist<Either<Failure, T>, T>,
+        DocDelete<Either<Failure, Null>>,
+        DocRead<Either<Failure, T?>>,
+        DocReplace<Either<Failure, Null>, T>,
+        DocUpdate<Either<Failure, Null>, T> {}

--- a/packages/firefuel/lib/src/repository.dart
+++ b/packages/firefuel/lib/src/repository.dart
@@ -3,7 +3,7 @@ import 'package:firefuel_core/firefuel_core.dart';
 
 import 'package:firefuel/src/rules.dart';
 
-abstract class Repository<inout T extends Serializable>
+abstract class Repository<T extends Serializable>
     implements
         CollectionRead<Either<Failure, List<T>>, T>,
         DocCreate<Either<Failure, DocumentId>, T>,

--- a/packages/firefuel/lib/src/rules.dart
+++ b/packages/firefuel/lib/src/rules.dart
@@ -1,0 +1,145 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import 'package:firefuel/firefuel.dart';
+
+/// Read a `List` of [T] from the Collection
+///
+/// [R]: should return a `List<T>` or some subset,
+/// i.e. `Either<Failure, List<T>>`
+///
+/// {@template firefuel.rules.subclasses}
+/// - Subclasses: [Collection] and [Repository] for subclasses
+/// {@endtemplate}
+/// {@template firefuel.rules.implementations}
+/// - Implementations: [FirefuelCollection] and [FirefuelRepository] for subclasses
+/// {@endtemplate}
+abstract class CollectionRead<R, T extends Serializable> {
+  /// Get a list of all documents from the collection as a list
+  ///
+  /// Refreshes automatically when new data is added to the collection
+  ///
+  /// See: StreamBuilder
+  Stream<R> listenAll(CollectionReference<T> ref);
+}
+
+/// Create a new Document
+///
+/// [R]: should return a [DocumentId] or some subset,
+/// i.e. `Either<Failure, DocumentId>`
+///
+/// {@macro firefuel.rules.subclasses}
+/// {@macro firefuel.rules.implementations}
+abstract class DocCreate<R, T extends Serializable> {
+  /// Create a new document with an auto-generated [DocumentId]
+  Future<R> create(T value);
+
+  /// Create a new document with the provided [docId]
+  Future<R> createById({
+    required T value,
+    required DocumentId docId,
+  });
+}
+
+/// Do some action, then create a Document if it doesn't exist
+///
+/// [R]: should return a [T] or some subset,
+/// i.e. `Either<Failure, T>`
+///
+/// {@macro firefuel.rules.subclasses}
+/// {@macro firefuel.rules.implementations}
+abstract class DocCreateIfNotExist<R, T extends Serializable> {
+  /// Get the document by id, or create a new one
+  ///
+  /// If the documentId returns a snapshot that does not exist, or `data()`
+  /// returns `null`, create a new document with the [docId] provided.
+  Future<R> readOrCreate({
+    required DocumentId docId,
+    required T createValue,
+  });
+
+  /// Updates data on the document if it exists. Data will be merged with
+  /// any existing document data.
+  ///
+  /// If no document exists, a new document will be created
+  ///
+  /// *Requires 1 read of doc to retrieve the new document*
+  Future<R> updateOrCreate({
+    required DocumentId docId,
+    required T value,
+  });
+}
+
+/// Delete an existing Document
+///
+/// [R]: should return [Null] or some subset,
+/// i.e. `Either<Failure, Null>`
+///
+/// {@macro firefuel.rules.subclasses}
+/// {@macro firefuel.rules.implementations}
+abstract class DocDelete<R> {
+  /// Deletes the current document from the collection.
+  Future<R> delete(DocumentId docId);
+}
+
+/// Read a Document
+///
+/// [R]: should return a [T?] or some subset,
+/// i.e. `Either<Failure, T?>`
+///
+/// {@macro firefuel.rules.subclasses}
+/// {@macro firefuel.rules.implementations}
+abstract class DocRead<R> {
+  /// Gets a stream of the document requested
+  Stream<R> listen(DocumentId docId);
+
+  /// Gets a single document from the collection
+  ///
+  /// Does NOT refresh automatically
+  Future<R> read(DocumentId docId);
+}
+
+/// Replace an existing Document
+///
+/// [R]: should return [Null] or some subset,
+/// i.e. `Either<Failure, Null>`
+///
+/// {@macro firefuel.rules.subclasses}
+/// {@macro firefuel.rules.implementations}
+abstract class DocReplace<R, T extends Serializable> {
+  /// Replaces the document at [docId] with [value].
+  ///
+  /// If no document exists yet, the replace will fail.
+  ///
+  /// *Requires 1 read of doc to perform replace*
+  Future<R> replace({required DocumentId docId, required T value});
+
+  /// Replaces the fields of the document at [docId] with the matching
+  /// [fieldPaths] from [value]
+  ///
+  /// Converts all [fieldPaths] into [FieldPath] objects to compare against
+  ///
+  /// If no document exists yet, the update will fail silently.
+  Future<R> replaceFields({
+    required DocumentId docId,
+    required T value,
+    required List<String> fieldPaths,
+  });
+}
+
+/// Update an existing Document
+///
+/// [R]: should return [Null] or some subset,
+/// i.e. `Either<Failure, Null>`
+///
+/// {@macro firefuel.rules.subclasses}
+/// {@macro firefuel.rules.implementations}
+abstract class DocUpdate<R, T extends Serializable> {
+  /// Updates data on the document. Data will be merged with any existing
+  /// document data.
+  ///
+  /// If no document exists yet, the update will fail silently.
+  Future<R> update({
+    required DocumentId docId,
+    required T value,
+  });
+}

--- a/packages/firefuel/lib/src/rules.dart
+++ b/packages/firefuel/lib/src/rules.dart
@@ -19,7 +19,7 @@ abstract class CollectionRead<R, T extends Serializable> {
   /// Refreshes automatically when new data is added to the collection
   ///
   /// See: StreamBuilder
-  Stream<R> listenAll(CollectionReference<T> ref);
+  Stream<R> listenAll();
 }
 
 /// Create a new Document

--- a/packages/firefuel/lib/src/rules.dart
+++ b/packages/firefuel/lib/src/rules.dart
@@ -62,7 +62,7 @@ abstract class DocCreateIfNotExist<R, T extends Serializable> {
   ///
   /// If no document exists, a new document will be created
   ///
-  /// *Requires 1 read of doc to retrieve the new document*
+  /// The value returned is the value passed in, a read is not performed
   Future<R> updateOrCreate({
     required DocumentId docId,
     required T value,

--- a/packages/firefuel/pubspec.lock
+++ b/packages/firefuel/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "22.0.0"
+    version: "25.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.1"
+    version: "2.2.0"
   args:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -49,7 +49,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   cli_util:
     dependency: transitive
     description:
@@ -193,6 +193,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.2"
   glob:
     dependency: transitive
     description:
@@ -248,7 +255,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:
@@ -414,21 +421,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.8"
+    version: "1.17.10"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.19"
+    version: "0.4.0"
   typed_data:
     dependency: transitive
     description:
@@ -479,5 +486,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=2.2.0"

--- a/packages/firefuel/pubspec.lock
+++ b/packages/firefuel/pubspec.lock
@@ -486,5 +486,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"
   flutter: ">=2.2.0"

--- a/packages/firefuel/pubspec.yaml
+++ b/packages/firefuel/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/SupposedlySam/firefuel
 publish_to: none
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.14.0 <3.0.0"
   flutter: ">=2.2.0 <3.0.0"
 
 dependencies:

--- a/packages/firefuel/pubspec.yaml
+++ b/packages/firefuel/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/SupposedlySam/firefuel
 publish_to: none
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.2.0 <3.0.0"
 
 dependencies:

--- a/packages/firefuel/test/mocks/mock_collection.dart
+++ b/packages/firefuel/test/mocks/mock_collection.dart
@@ -6,7 +6,7 @@ import 'package:firefuel/firefuel.dart';
 import 'package:firefuel/src/collection.dart';
 import '../utils/test_user.dart';
 
-class MockCollection<T extends Serializable> extends Mock
+class MockCollection<inout T extends Serializable> extends Mock
     implements Collection<T> {}
 
 extension MockCollectionX<T extends Serializable> on MockCollection<T> {
@@ -29,7 +29,7 @@ extension MockCollectionX<T extends Serializable> on MockCollection<T> {
     }
 
     if (onReadAsStream != null) {
-      when(() => readAsStream(any())).thenAnswer((_) => onReadAsStream());
+      when(() => listen(any())).thenAnswer((_) => onReadAsStream());
     }
 
     if (onUpdate != null) {

--- a/packages/firefuel/test/mocks/mock_collection.dart
+++ b/packages/firefuel/test/mocks/mock_collection.dart
@@ -6,7 +6,7 @@ import 'package:firefuel/firefuel.dart';
 import 'package:firefuel/src/collection.dart';
 import '../utils/test_user.dart';
 
-class MockCollection<inout T extends Serializable> extends Mock
+class MockCollection<T extends Serializable> extends Mock
     implements Collection<T> {}
 
 extension MockCollectionX<T extends Serializable> on MockCollection<T> {

--- a/packages/firefuel/test/src/firefuel_collection_test.dart
+++ b/packages/firefuel/test/src/firefuel_collection_test.dart
@@ -142,7 +142,7 @@ void main() {
       docId = await testCollection.create(defaultUser);
       await testCollection.create(newUser1);
 
-      stream = testCollection.listenAll(testCollection.ref);
+      stream = testCollection.listenAll();
     });
 
     test('should update when an item is added', () async {

--- a/packages/firefuel/test/src/firefuel_collection_test.dart
+++ b/packages/firefuel/test/src/firefuel_collection_test.dart
@@ -107,7 +107,7 @@ void main() {
     setUp(() async {
       docId = await testCollection.create(defaultUser);
 
-      stream = testCollection.listen(testCollection.ref, docId);
+      stream = testCollection.listen(docId);
     });
 
     test('should output new value when doc updates', () async {

--- a/packages/firefuel/test/src/firefuel_repository_test.dart
+++ b/packages/firefuel/test/src/firefuel_repository_test.dart
@@ -18,7 +18,7 @@ void main() {
       mockCollection.initialize(onCreate: () => throw ExpectedFailure());
     },
     methodCallback: (testRepository) {
-      return testRepository.create(value: defaultUser);
+      return testRepository.create(defaultUser);
     },
   );
 
@@ -48,7 +48,7 @@ void main() {
       mockCollection.initialize(onReadAsStream: () => throw ExpectedFailure());
     },
     streamCallback: (testRepository) {
-      return testRepository.readAsStream(docId);
+      return testRepository.listen(docId);
     },
   );
 

--- a/packages/firefuel/test/src/firefuel_test.dart
+++ b/packages/firefuel/test/src/firefuel_test.dart
@@ -1,7 +1,8 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
-import 'package:firefuel/firefuel.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'package:firefuel/firefuel.dart';
 
 void main() {
   group('#firestore', () {


### PR DESCRIPTION
[Project Card Link]()

### Reason for Change
Breaking up the Collection methods into smaller classes allows for more control over permissions by collection. Smaller abstract classes also allow us to specify a return type for each class individually, making it possible to share the rules classes between Collection and Repository

### Proposed Changes
- Separate the Collection abstract class into multiple "rule" classes we can implement in both Collection and Repository
- Change the return type of `createById` to `DocumentId` to match the return type convention of the `DocCreate` abstract class
- Have `updateOrCreate` return `T` since it can create a class that didn't exist before (also follows the return type convention for the rule abstract class it now resides in`
- Bump dependencies
- Pass through all `Collection` methods through to the `Repository` 

### Breaking Changes
- Rename `readAsStream` to `listen`
- Remove duplicate `listen` class that previously accepted a `CollectionRef`


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore


### Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Readme Updated
- [ ] Example project updated
- [x] Tests added/updated
- [ ] Changelog updated
- [ ] Pubspec version updated
