### PR TITLE
feat: add where and listenWhere to Collection/Repo

### DIFF
--- a/packages/firefuel/lib/firefuel.dart
+++ b/packages/firefuel/lib/firefuel.dart
@@ -1,12 +1,26 @@
 library firefuel;
 
-export 'package:dartz/dartz.dart' show Either, Right, Left, left;
+export 'package:cloud_firestore/cloud_firestore.dart'
+    show
+        CollectionReference,
+        DocumentSnapshot,
+        FieldPath,
+        Query,
+        QuerySnapshot,
+        QueryDocumentSnapshot,
+        SetOptions,
+        SnapshotOptions;
+export 'package:dartz/dartz.dart' show Either, Left, left, Right, right;
+export 'package:firefuel/src/clause.dart';
+export 'package:firefuel/src/collection.dart';
+export 'package:firefuel/src/repository.dart';
 export 'package:firefuel/src/firefuel.dart';
 export 'package:firefuel/src/firefuel_collection.dart';
 export 'package:firefuel/src/firefuel_failure.dart';
 export 'package:firefuel/src/firefuel_fetch_mixin.dart';
 export 'package:firefuel/src/firefuel_repository.dart';
 export 'package:firefuel/src/rules.dart';
+export 'package:firefuel/src/snapshot_conversion_mixin.dart';
 export 'package:firefuel/src/utils/either_extensions.dart';
 export 'package:firefuel/src/utils/exceptions.dart';
 export 'package:firefuel_core/firefuel_core.dart';

--- a/packages/firefuel/lib/src/clause.dart
+++ b/packages/firefuel/lib/src/clause.dart
@@ -1,3 +1,27 @@
+import 'package:firefuel/firefuel.dart';
+
+/// Creates a condition to filter your Collection
+///
+/// [field] must be provided and is normally the string representation of the
+/// field on your document to match against.
+///
+/// It's recommended to store field names on your model so you can access them
+/// with `MyModel.field<YourField>` where `MyModel` references the class you're
+/// serializing your Document into, and `field<YourField>` is the naming
+/// convention to follow (don't include the angle brackets).
+///
+/// ## Examples
+///
+/// ### Good
+/// ```dart
+/// Clause(MyModel.fieldAge, isEqualTo: 23);
+/// ```
+///
+/// ### Bad - Throws [TooManyArgumentsException]
+///
+/// ```dart
+/// Clause(MyModel.fieldVehicle, isEqualTo: 'Mazda', isNotEqualTo: 'Honda');
+/// ```
 class Clause {
   final Object field;
 
@@ -25,5 +49,28 @@ class Clause {
     this.whereIn,
     this.whereNotIn,
     this.isNull,
-  });
+  }) {
+    _ensureSingleOptionChosen([
+      isEqualTo,
+      isNotEqualTo,
+      isLessThan,
+      isLessThanOrEqualTo,
+      isGreaterThan,
+      isGreaterThanOrEqualTo,
+      arrayContains,
+      arrayContainsAny,
+      whereIn,
+      whereNotIn,
+      isNull
+    ]);
+  }
+
+  /// Checks for non-null options and throws a [TooManyArgumentsException] when
+  /// more than one option is provided
+  void _ensureSingleOptionChosen(List<dynamic> options) {
+    final providedOptionLength = options.where((e) => e != null).length;
+    if (providedOptionLength == 1) return;
+
+    throw TooManyArgumentsException();
+  }
 }

--- a/packages/firefuel/lib/src/clause.dart
+++ b/packages/firefuel/lib/src/clause.dart
@@ -1,0 +1,29 @@
+class Clause {
+  final Object field;
+
+  final Object? isEqualTo;
+  final Object? isNotEqualTo;
+  final Object? isLessThan;
+  final Object? isLessThanOrEqualTo;
+  final Object? isGreaterThan;
+  final Object? isGreaterThanOrEqualTo;
+  final Object? arrayContains;
+  final List<Object?>? arrayContainsAny;
+  final List<Object?>? whereIn;
+  final List<Object?>? whereNotIn;
+  final bool? isNull;
+  Clause(
+    this.field, {
+    this.isEqualTo,
+    this.isNotEqualTo,
+    this.isLessThan,
+    this.isLessThanOrEqualTo,
+    this.isGreaterThan,
+    this.isGreaterThanOrEqualTo,
+    this.arrayContains,
+    this.arrayContainsAny,
+    this.whereIn,
+    this.whereNotIn,
+    this.isNull,
+  });
+}

--- a/packages/firefuel/lib/src/firefuel_collection.dart
+++ b/packages/firefuel/lib/src/firefuel_collection.dart
@@ -66,7 +66,7 @@ abstract class FirefuelCollection<T extends Serializable>
   }
 
   @override
-  Stream<List<T>> listenWhere(Iterable<Clause> clauses) {
+  Stream<List<T>> listenWhere(List<Clause> clauses) {
     return _queryFromClauses(clauses).snapshots().toListT();
   }
 
@@ -149,13 +149,13 @@ abstract class FirefuelCollection<T extends Serializable>
   }
 
   @override
-  Future<List<T>> where(Iterable<Clause> clauses) async {
+  Future<List<T>> where(List<Clause> clauses) async {
     final snapshot = await _queryFromClauses(clauses).get();
 
     return snapshot.docs.toListT();
   }
 
-  Query<T?> _queryFromClauses(Iterable<Clause> clauses) {
+  Query<T?> _queryFromClauses(List<Clause> clauses) {
     if (clauses.isEmpty) throw MissingValueException(Clause);
 
     return clauses.fold(ref, (result, clause) {

--- a/packages/firefuel/lib/src/firefuel_collection.dart
+++ b/packages/firefuel/lib/src/firefuel_collection.dart
@@ -65,6 +65,7 @@ abstract class FirefuelCollection<T extends Serializable>
     return ref.snapshots().toListT();
   }
 
+  @override
   Stream<List<T>> listenWhere(Iterable<Clause> clauses) {
     return _queryFromClauses(clauses).snapshots().toListT();
   }
@@ -147,6 +148,7 @@ abstract class FirefuelCollection<T extends Serializable>
     return value;
   }
 
+  @override
   Future<List<T>> where(Iterable<Clause> clauses) async {
     final snapshot = await _queryFromClauses(clauses).get();
 

--- a/packages/firefuel/lib/src/firefuel_repository.dart
+++ b/packages/firefuel/lib/src/firefuel_repository.dart
@@ -1,9 +1,4 @@
-import 'package:dartz/dartz.dart';
-import 'package:firefuel_core/firefuel_core.dart';
-
 import 'package:firefuel/firefuel.dart';
-import 'package:firefuel/src/collection.dart';
-import 'package:firefuel/src/repository.dart';
 
 abstract class FirefuelRepository<T extends Serializable>
     with FirefuelFetchMixin

--- a/packages/firefuel/lib/src/firefuel_repository.dart
+++ b/packages/firefuel/lib/src/firefuel_repository.dart
@@ -37,7 +37,7 @@ abstract class FirefuelRepository<T extends Serializable>
   }
 
   @override
-  Stream<Either<Failure, List<T>>> listenWhere(Iterable<Clause> clauses) {
+  Stream<Either<Failure, List<T>>> listenWhere(List<Clause> clauses) {
     return guardStream(() => _collection.listenWhere(clauses));
   }
 
@@ -104,7 +104,7 @@ abstract class FirefuelRepository<T extends Serializable>
   }
 
   @override
-  Future<Either<Failure, List<T>>> where(Iterable<Clause> clauses) {
+  Future<Either<Failure, List<T>>> where(List<Clause> clauses) {
     return guard(() => _collection.where(clauses));
   }
 }

--- a/packages/firefuel/lib/src/firefuel_repository.dart
+++ b/packages/firefuel/lib/src/firefuel_repository.dart
@@ -37,6 +37,11 @@ abstract class FirefuelRepository<T extends Serializable>
   }
 
   @override
+  Stream<Either<Failure, List<T>>> listenWhere(Iterable<Clause> clauses) {
+    return guardStream(() => _collection.listenWhere(clauses));
+  }
+
+  @override
   Future<Either<Failure, T?>> read(DocumentId docId) async {
     return guard(() => _collection.read(docId));
   }
@@ -96,5 +101,10 @@ abstract class FirefuelRepository<T extends Serializable>
     required T value,
   }) {
     return guard(() => _collection.updateOrCreate(docId: docId, value: value));
+  }
+
+  @override
+  Future<Either<Failure, List<T>>> where(Iterable<Clause> clauses) {
+    return guard(() => _collection.where(clauses));
   }
 }

--- a/packages/firefuel/lib/src/rules.dart
+++ b/packages/firefuel/lib/src/rules.dart
@@ -16,10 +16,23 @@ import 'package:firefuel/firefuel.dart';
 abstract class CollectionRead<R, T extends Serializable> {
   /// Get a list of all documents from the collection as a list
   ///
-  /// Refreshes automatically when new data is added to the collection
+  /// Refreshes automatically when new data is added/removed from the collection
   ///
   /// See: StreamBuilder
   Stream<R> listenAll();
+
+  /// Get a list of documents matching all clauses
+  ///
+  /// throws a [MissingValueException] when no [Clause]s are given
+  Future<R> where(Iterable<Clause> clauses);
+
+  /// Get a list of documents matching all clauses
+  ///
+  /// Refreshes automatically when new matching data is added/removed from the
+  /// collection
+  ///
+  /// throws a [MissingValueException] when no [Clause]s are given
+  Stream<R> listenWhere(Iterable<Clause> clauses);
 }
 
 /// Create a new Document

--- a/packages/firefuel/lib/src/rules.dart
+++ b/packages/firefuel/lib/src/rules.dart
@@ -24,7 +24,7 @@ abstract class CollectionRead<R, T extends Serializable> {
   /// Get a list of documents matching all clauses
   ///
   /// throws a [MissingValueException] when no [Clause]s are given
-  Future<R> where(Iterable<Clause> clauses);
+  Future<R> where(List<Clause> clauses);
 
   /// Get a list of documents matching all clauses
   ///
@@ -32,7 +32,7 @@ abstract class CollectionRead<R, T extends Serializable> {
   /// collection
   ///
   /// throws a [MissingValueException] when no [Clause]s are given
-  Stream<R> listenWhere(Iterable<Clause> clauses);
+  Stream<R> listenWhere(List<Clause> clauses);
 }
 
 /// Create a new Document

--- a/packages/firefuel/lib/src/snapshot_conversion_mixin.dart
+++ b/packages/firefuel/lib/src/snapshot_conversion_mixin.dart
@@ -1,0 +1,24 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+extension QuerySnapshotX<T> on Stream<QuerySnapshot<T?>> {
+  /// Get all non-null data from the [QuerySnapshot] documents
+  Stream<List<T>> toListT() {
+    return map(
+      (snapshot) => snapshot.docs.toListT(),
+    );
+  }
+}
+
+extension QueryDocumentSnapshotX<T> on List<QueryDocumentSnapshot<T?>> {
+  /// Get all non-null data from [QueryDocumentSnapshot] as a [List]
+  List<T> toListT() {
+    return map((doc) => doc.data()).whereType<T>().toList();
+  }
+}
+
+extension DocumentSnapshotX<T> on Stream<DocumentSnapshot<T?>> {
+  /// Get data from the [DocumentSnapshot]
+  Stream<T?> toMaybeT() {
+    return map((snapshot) => snapshot.data());
+  }
+}

--- a/packages/firefuel/lib/src/utils/exceptions.dart
+++ b/packages/firefuel/lib/src/utils/exceptions.dart
@@ -8,3 +8,5 @@ class MissingValueException implements Exception {
     return '$MissingValueException:$type';
   }
 }
+
+class TooManyArgumentsException implements Exception {}

--- a/packages/firefuel/test/mocks/mock_collection.dart
+++ b/packages/firefuel/test/mocks/mock_collection.dart
@@ -17,6 +17,7 @@ extension MockCollectionX<T extends Serializable> on MockCollection<T> {
     Stream<List<T>> Function()? onListenWhere,
     Null Function()? onUpdate,
     Null Function()? onDelete,
+    List<T> Function()? onWhere,
   }) {
     registerFallbackValue(DocumentId('fallbackValue'));
     registerFallbackValue<Serializable>(TestUser('fallbackValue'));
@@ -46,6 +47,10 @@ extension MockCollectionX<T extends Serializable> on MockCollection<T> {
 
     if (onDelete != null) {
       when(() => delete(any())).thenAnswer((_) => Future.value(onDelete()));
+    }
+
+    if (onWhere != null) {
+      when(() => where(any())).thenAnswer((_) => Future.value(onWhere()));
     }
   }
 }

--- a/packages/firefuel/test/mocks/mock_collection.dart
+++ b/packages/firefuel/test/mocks/mock_collection.dart
@@ -13,7 +13,8 @@ extension MockCollectionX<T extends Serializable> on MockCollection<T> {
   void initialize({
     DocumentId Function()? onCreate,
     T? Function()? onRead,
-    Stream<T?> Function()? onReadAsStream,
+    Stream<T?> Function()? onListen,
+    Stream<List<T>> Function()? onListenWhere,
     Null Function()? onUpdate,
     Null Function()? onDelete,
   }) {
@@ -28,8 +29,14 @@ extension MockCollectionX<T extends Serializable> on MockCollection<T> {
       when(() => read(any())).thenAnswer((_) => Future.value(onRead()));
     }
 
-    if (onReadAsStream != null) {
-      when(() => listen(any())).thenAnswer((_) => onReadAsStream());
+    if (onListen != null) {
+      when(() => listen(any())).thenAnswer((_) => onListen());
+    }
+
+    if (onListenWhere != null) {
+      when(() => listenWhere(any())).thenAnswer(
+        (_) => onListenWhere(),
+      );
     }
 
     if (onUpdate != null) {

--- a/packages/firefuel/test/src/firefuel_collection_test.dart
+++ b/packages/firefuel/test/src/firefuel_collection_test.dart
@@ -430,20 +430,23 @@ void main() {
       expect(filteredList, [expectedUser]);
     });
 
-    test('should return an empty list when more than one option is chosen',
-        () async {
-      final filteredList = await testCollection.where(
-        [
-          Clause(
-            TestUser.fieldName,
-            isNotEqualTo: unexpectedName1,
-            isEqualTo: expectedUser,
+    test(
+      'should throw a $TooManyArgumentsException when more than one option is chosen',
+      () {
+        expect(
+          () async => await testCollection.where(
+            [
+              Clause(
+                TestUser.fieldName,
+                isNotEqualTo: unexpectedName1,
+                isEqualTo: expectedUser,
+              ),
+            ],
           ),
-        ],
-      );
-
-      expect(filteredList, []);
-    });
+          throwsA(isA<TooManyArgumentsException>()),
+        );
+      },
+    );
 
     test('should throw when no clauses are given', () async {
       expect(

--- a/packages/firefuel/test/src/firefuel_repository_test.dart
+++ b/packages/firefuel/test/src/firefuel_repository_test.dart
@@ -106,4 +106,26 @@ void main() {
     },
     methodCallback: (testRepository) => testRepository.delete(docId),
   );
+
+  RepositoryTestUtil.runTests<List<TestUser>, TestUser>(
+    methodName: 'where',
+    mockCollection: MockCollection(),
+    initHappyPath: (mockCollection) async {
+      mockCollection.initialize(
+        onWhere: () => [
+          TestUser('unexpectedUser1'),
+          TestUser('expectedUser'),
+          TestUser('unexpectedUser2'),
+        ],
+      );
+    },
+    initSadPath: (mockCollection) async {
+      mockCollection.initialize(onWhere: () => throw ExpectedFailure());
+    },
+    methodCallback: (testRepository) {
+      return testRepository.where([
+        Clause(TestUser.fieldName, isEqualTo: 'expectedUser'),
+      ]);
+    },
+  );
 }

--- a/packages/firefuel/test/src/firefuel_repository_test.dart
+++ b/packages/firefuel/test/src/firefuel_repository_test.dart
@@ -35,20 +35,46 @@ void main() {
   );
 
   RepositoryTestUtil.runStreamTests<TestUser?, TestUser>(
-    methodName: 'readAsStream',
+    methodName: 'listen',
     mockCollection: MockCollection(),
     initHappyPath: (mockCollection) async {
       mockCollection.initialize(
-        onReadAsStream: () => Stream.fromIterable(
+        onListen: () => Stream.fromIterable(
           [TestUser('streamUser')],
         ),
       );
     },
     initSadPath: (mockCollection) async {
-      mockCollection.initialize(onReadAsStream: () => throw ExpectedFailure());
+      mockCollection.initialize(onListen: () => throw ExpectedFailure());
     },
     streamCallback: (testRepository) {
       return testRepository.listen(docId);
+    },
+  );
+
+  RepositoryTestUtil.runStreamTests<List<TestUser>, TestUser>(
+    methodName: 'listenWhere',
+    mockCollection: MockCollection(),
+    initHappyPath: (mockCollection) async {
+      mockCollection.initialize(
+        onListenWhere: () => Stream.fromIterable(
+          [
+            [
+              TestUser('unexpectedUser1'),
+              TestUser('expectedUser'),
+              TestUser('unexpectedUser2'),
+            ]
+          ],
+        ),
+      );
+    },
+    initSadPath: (mockCollection) async {
+      mockCollection.initialize(onListenWhere: () => throw ExpectedFailure());
+    },
+    streamCallback: (testRepository) {
+      return testRepository.listenWhere([
+        Clause(TestUser.fieldName, isEqualTo: 'expectedUser'),
+      ]);
     },
   );
 

--- a/packages/firefuel_env/pubspec.lock
+++ b/packages/firefuel_env/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -73,7 +73,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Resolves [Issue #16](https://github.com/SupposedlySam/firefuel/issues/16#issue-989232363)

### Reason for Change
To get a subset of the documents inside a collection, currently you need to do something like this

```dart
    final snapshot = await myCollection.ref.where('myField', isEqualTo: 'myValue').get();

    return shapshot.docs.map((doc) => doc.data()).whereType<T>().toList();
```

^this is way too verbose to be doing every time you want to filter your collection.

### Proposed Changes
- Create a `Clause` class to mimic the current `where` function on a `CollectionReference` and `Query`
- Add a `where` method to Collection (pass through to Repo) that returns a `Future<List<T>>` and accepts a `List<Clause>`.
- Add a `listenWhere` method to Collection (pass through to Repo) that returns a `Stream<List<T>>` and accepts a `List<Clause>`.  

This will drastically simplify the code needed from what's seen above, to this
```dart
    return await testCollection.where(
        [Clause('myField', isEqualTo: 'myValue')],
    );
```

As a bonus, you don't need to chain multiple where clauses as before, but just pass all your clauses in at once.

```dart
    return await testCollection.where([
        Clause('myField', isNotEqualTo: 'myValue1'),
        Clause('myField', isNotEqualTo: 'myValue2'),
    ]);

```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


### Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Readme Updated
- [ ] Example project updated
- [x] Tests added/updated
- [ ] Changelog updated
- [ ] Pubspec version updated
