### PR TITLE
feat: add pagination ability

### DIFF
--- a/packages/firefuel/lib/firefuel.dart
+++ b/packages/firefuel/lib/firefuel.dart
@@ -24,4 +24,5 @@ export 'package:firefuel/src/rules.dart';
 export 'package:firefuel/src/snapshot_conversion_mixin.dart';
 export 'package:firefuel/src/utils/either_extensions.dart';
 export 'package:firefuel/src/utils/exceptions.dart';
+export 'package:firefuel/src/utils/query_extensions.dart';
 export 'package:firefuel_core/firefuel_core.dart';

--- a/packages/firefuel/lib/firefuel.dart
+++ b/packages/firefuel/lib/firefuel.dart
@@ -11,6 +11,7 @@ export 'package:cloud_firestore/cloud_firestore.dart'
         SetOptions,
         SnapshotOptions;
 export 'package:dartz/dartz.dart' show Either, Left, left, Right, right;
+export 'package:firefuel/src/chunk.dart';
 export 'package:firefuel/src/clause.dart';
 export 'package:firefuel/src/collection.dart';
 export 'package:firefuel/src/repository.dart';

--- a/packages/firefuel/lib/src/chunk.dart
+++ b/packages/firefuel/lib/src/chunk.dart
@@ -1,30 +1,30 @@
 import 'package:firefuel/firefuel.dart';
 
-enum ChunkStatus { starting, nextAvailable, last }
+enum ChunkStatus { nextAvailable, last }
 
 /// Used to keep track of state when paginating
 class Chunk<T> {
   static const int defaultLimit = 25;
 
-  final DocumentSnapshot? cursor;
+  final DocumentSnapshot<T?>? cursor;
   final List<T> data;
   final int limit;
-  final String? orderByField;
+  final String orderByField;
   final List<Clause>? clauses;
   final ChunkStatus status;
 
   Chunk({
-    this.orderByField,
+    required this.orderByField,
     this.clauses,
     this.limit = defaultLimit,
   })  : data = [],
         cursor = null,
-        status = ChunkStatus.starting;
+        status = ChunkStatus.nextAvailable;
 
   Chunk.next({
     required this.data,
     required this.cursor,
-    this.orderByField,
+    required this.orderByField,
     this.clauses,
     this.limit = defaultLimit,
   }) : status = ChunkStatus.nextAvailable;
@@ -32,7 +32,7 @@ class Chunk<T> {
   Chunk.last({
     required this.data,
     required this.cursor,
-    this.orderByField,
+    required this.orderByField,
     this.clauses,
     this.limit = defaultLimit,
   }) : status = ChunkStatus.last;

--- a/packages/firefuel/lib/src/chunk.dart
+++ b/packages/firefuel/lib/src/chunk.dart
@@ -4,19 +4,19 @@ enum ChunkStatus { starting, nextAvailable, last }
 
 /// Used to keep track of state when paginating
 class Chunk<T> {
-  static const int _defaultLimit = 25;
+  static const int defaultLimit = 25;
 
   final DocumentSnapshot? cursor;
   final List<T> data;
   final int limit;
   final String? orderByField;
-  final List<Clause>? whereClauses;
+  final List<Clause>? clauses;
   final ChunkStatus status;
 
   Chunk({
     this.orderByField,
-    this.whereClauses,
-    this.limit = _defaultLimit,
+    this.clauses,
+    this.limit = defaultLimit,
   })  : data = [],
         cursor = null,
         status = ChunkStatus.starting;
@@ -25,15 +25,15 @@ class Chunk<T> {
     required this.data,
     required this.cursor,
     this.orderByField,
-    this.whereClauses,
-    this.limit = _defaultLimit,
+    this.clauses,
+    this.limit = defaultLimit,
   }) : status = ChunkStatus.nextAvailable;
 
   Chunk.last({
     required this.data,
     required this.cursor,
     this.orderByField,
-    this.whereClauses,
-    this.limit = _defaultLimit,
+    this.clauses,
+    this.limit = defaultLimit,
   }) : status = ChunkStatus.last;
 }

--- a/packages/firefuel/lib/src/chunk.dart
+++ b/packages/firefuel/lib/src/chunk.dart
@@ -1,0 +1,39 @@
+import 'package:firefuel/firefuel.dart';
+
+enum ChunkStatus { starting, nextAvailable, last }
+
+/// Used to keep track of state when paginating
+class Chunk<T> {
+  static const int _defaultLimit = 25;
+
+  final DocumentSnapshot? cursor;
+  final List<T> data;
+  final int limit;
+  final String? orderByField;
+  final List<Clause>? whereClauses;
+  final ChunkStatus status;
+
+  Chunk({
+    this.orderByField,
+    this.whereClauses,
+    this.limit = _defaultLimit,
+  })  : data = [],
+        cursor = null,
+        status = ChunkStatus.starting;
+
+  Chunk.next({
+    required this.data,
+    required this.cursor,
+    this.orderByField,
+    this.whereClauses,
+    this.limit = _defaultLimit,
+  }) : status = ChunkStatus.nextAvailable;
+
+  Chunk.last({
+    required this.data,
+    required this.cursor,
+    this.orderByField,
+    this.whereClauses,
+    this.limit = _defaultLimit,
+  }) : status = ChunkStatus.last;
+}

--- a/packages/firefuel/lib/src/collection.dart
+++ b/packages/firefuel/lib/src/collection.dart
@@ -1,11 +1,9 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firefuel_core/firefuel_core.dart';
-
-import 'package:firefuel/src/rules.dart';
+import 'package:firefuel/firefuel.dart';
 
 abstract class Collection<T extends Serializable>
     implements
         CollectionRead<List<T>, T>,
+        CollectionPaginate<Chunk<T>, T>,
         DocCreate<DocumentId, T>,
         DocCreateIfNotExist<T, T>,
         DocDelete<Null>,

--- a/packages/firefuel/lib/src/firefuel_collection.dart
+++ b/packages/firefuel/lib/src/firefuel_collection.dart
@@ -106,11 +106,18 @@ abstract class FirefuelCollection<T extends Serializable>
   Future<QuerySnapshot<T?>> _buildPaginationSnapshot(Chunk<T> chunk) async {
     final needsOrdering = chunk.orderByField != null;
 
-    final query = needsOrdering
-        ? ref.orderBy(chunk.orderByField!).limit(chunk.limit)
-        : ref.limit(chunk.limit);
+    var query = ref
+        .filterIfNotNull(chunk.clauses)
+        .orderIfNotNull(chunk.orderByField)
+        .limitIfNotNull(chunk.limit);
 
     return query.get();
+  }
+
+  Query<T?> filterRef(Chunk<T> chunk, List<Clause>? clauses) {
+    if (clauses == null) return ref;
+
+    return _queryFromClauses(chunk.clauses!);
   }
 
   @override

--- a/packages/firefuel/lib/src/firefuel_collection.dart
+++ b/packages/firefuel/lib/src/firefuel_collection.dart
@@ -85,6 +85,7 @@ abstract class FirefuelCollection<T extends Serializable>
     return query.snapshots().toListT();
   }
 
+  @override
   Future<Chunk<T>> paginate(Chunk<T> chunk) async {
     final snapshot = await _buildPaginationSnapshot(chunk);
 

--- a/packages/firefuel/lib/src/firefuel_repository.dart
+++ b/packages/firefuel/lib/src/firefuel_repository.dart
@@ -55,6 +55,11 @@ abstract class FirefuelRepository<T extends Serializable>
   }
 
   @override
+  Future<Either<Failure, Chunk<T>>> paginate(Chunk<T> chunk) {
+    return guard(() => _collection.paginate(chunk));
+  }
+
+  @override
   Future<Either<Failure, T?>> read(DocumentId docId) async {
     return guard(() => _collection.read(docId));
   }

--- a/packages/firefuel/lib/src/repository.dart
+++ b/packages/firefuel/lib/src/repository.dart
@@ -1,14 +1,14 @@
-import 'package:dartz/dartz.dart';
-import 'package:firefuel_core/firefuel_core.dart';
-
-import 'package:firefuel/src/rules.dart';
+import 'package:firefuel/firefuel.dart';
 
 abstract class Repository<T extends Serializable>
     implements
         CollectionRead<Either<Failure, List<T>>, T>,
+        CollectionPaginate<Either<Failure, Chunk<T>>, T>,
         DocCreate<Either<Failure, DocumentId>, T>,
         DocCreateIfNotExist<Either<Failure, T>, T>,
         DocDelete<Either<Failure, Null>>,
         DocRead<Either<Failure, T?>>,
         DocReplace<Either<Failure, Null>, T>,
-        DocUpdate<Either<Failure, Null>, T> {}
+        DocUpdate<Either<Failure, Null>, T> {
+  const Repository();
+}

--- a/packages/firefuel/lib/src/rules.dart
+++ b/packages/firefuel/lib/src/rules.dart
@@ -50,6 +50,27 @@ abstract class CollectionRead<R, T extends Serializable> {
   Stream<R> listenWhere(List<Clause> clauses, {int? limit});
 }
 
+/// Get a number of Documents from the Collection
+///
+/// /// [R]: should return a [T] or some subset,
+/// i.e. `Either<Failure, T>`
+///
+/// {@macro firefuel.rules.subclasses}
+/// {@macro firefuel.rules.implementations}
+abstract class CollectionPaginate<R, T extends Serializable> {
+  /// Get a number of Documents from the Collection specified by the [chunk]
+  ///
+  /// Store the [Chunk] you get back from calling this method and pass it back
+  /// to the [paginate] method to get the next [Chunk]
+  ///
+  /// You can continue to do this until the `Chunk.status` equals
+  /// [ChunkStatus.last].
+  ///
+  /// Passing in a [Chunk] with the status of [ChunkStatus.last] will result in
+  /// a [Chunk] with empty data.
+  Future<R> paginate(Chunk<T> chunk);
+}
+
 /// Create a new Document
 ///
 /// [R]: should return a [DocumentId] or some subset,

--- a/packages/firefuel/lib/src/utils/query_extensions.dart
+++ b/packages/firefuel/lib/src/utils/query_extensions.dart
@@ -1,0 +1,35 @@
+import 'package:firefuel/firefuel.dart';
+
+extension QueryX<T> on Query<T?> {
+  Query<T?> filterIfNotNull(List<Clause>? clauses) {
+    if (clauses?.isEmpty ?? true) return this;
+
+    return clauses!.fold(this, (result, clause) {
+      return result.where(
+        clause.field,
+        isEqualTo: clause.isEqualTo,
+        isNotEqualTo: clause.isNotEqualTo,
+        isLessThan: clause.isLessThan,
+        isLessThanOrEqualTo: clause.isLessThanOrEqualTo,
+        isGreaterThan: clause.isGreaterThan,
+        isGreaterThanOrEqualTo: clause.isGreaterThanOrEqualTo,
+        arrayContains: clause.arrayContains,
+        whereIn: clause.whereIn,
+        whereNotIn: clause.whereNotIn,
+        isNull: clause.isNull,
+      );
+    });
+  }
+
+  Query<T?> orderIfNotNull(String? field) {
+    if (field == null) return this;
+
+    return orderBy(field);
+  }
+
+  Query<T?> limitIfNotNull(int? limit) {
+    if (limit == null) return this;
+
+    return this.limit(limit);
+  }
+}

--- a/packages/firefuel/lib/src/utils/query_extensions.dart
+++ b/packages/firefuel/lib/src/utils/query_extensions.dart
@@ -21,6 +21,12 @@ extension QueryX<T> on Query<T?> {
     });
   }
 
+  Query<T?> startAfterIfNotNull(DocumentSnapshot<T?>? cursor) {
+    if (cursor == null) return this;
+
+    return startAfterDocument(cursor);
+  }
+
   Query<T?> orderIfNotNull(String? field) {
     if (field == null) return this;
 

--- a/packages/firefuel/test/mocks/mock_collection.dart
+++ b/packages/firefuel/test/mocks/mock_collection.dart
@@ -19,6 +19,7 @@ extension MockCollectionX<T extends Serializable> on MockCollection<T> {
     Stream<List<T>> Function()? onListenAll,
     Stream<List<T>> Function()? onListenLimited,
     Stream<List<T>> Function()? onListenWhere,
+    Chunk<T> Function()? onPaginate,
     T? Function()? onRead,
     T Function()? onReadOrCreate,
     Null Function()? onReplace,
@@ -29,6 +30,7 @@ extension MockCollectionX<T extends Serializable> on MockCollection<T> {
   }) {
     registerFallbackValue(DocumentId('fallbackValue'));
     registerFallbackValue<Serializable>(TestUser('fallbackValue'));
+    registerFallbackValue(Chunk<TestUser>(orderByField: TestUser.fieldName));
 
     if (onCreate != null) {
       when(() => create(any())).thenAnswer((_) => Future.value(onCreate()));
@@ -69,6 +71,10 @@ extension MockCollectionX<T extends Serializable> on MockCollection<T> {
       }).thenAnswer(
         (_) => onListenWhere(),
       );
+    }
+
+    if (onPaginate != null) {
+      when(() => paginate(any())).thenAnswer((_) => Future.value(onPaginate()));
     }
 
     if (onRead != null) {

--- a/packages/firefuel/test/src/firefuel_repository_test.dart
+++ b/packages/firefuel/test/src/firefuel_repository_test.dart
@@ -165,6 +165,24 @@ void main() {
     },
   );
 
+  RepositoryTestUtil.runTests<Chunk<TestUser>, TestUser>(
+    methodName: 'paginate',
+    mockCollection: MockCollection(),
+    initHappyPath: (mockCollection) async {
+      mockCollection.initialize(onPaginate: () {
+        return Chunk<TestUser>(orderByField: TestUser.fieldName);
+      });
+    },
+    initSadPath: (mockCollection) async {
+      mockCollection.initialize(onPaginate: () => throw ExpectedFailure());
+    },
+    methodCallback: (testRepository) {
+      return testRepository.paginate(
+        Chunk<TestUser>(orderByField: TestUser.fieldName),
+      );
+    },
+  );
+
   RepositoryTestUtil.runTests<TestUser?, TestUser>(
     methodName: 'read',
     mockCollection: MockCollection(),

--- a/packages/firefuel/test/src/utils/query_extensions_test.dart
+++ b/packages/firefuel/test/src/utils/query_extensions_test.dart
@@ -39,7 +39,7 @@ void main() {
 
   group('#startAfterIfNotNull', () {
     test('should return the original query when null', () {
-      final result = ref.filterIfNotNull(null);
+      final result = ref.startAfterIfNotNull(null);
 
       expect(identityHashCode(result), identityHashCode(ref));
     });
@@ -55,6 +55,20 @@ void main() {
   });
 
   group('#orderIfNotNull', () {
+    test('should return the original query when null', () {
+      final result = ref.orderIfNotNull(null);
+
+      expect(identityHashCode(result), identityHashCode(ref));
+    });
+
+    test('should return a new query when not null', () async {
+      final result = ref.orderIfNotNull(TestUser.fieldName);
+
+      expect(identityHashCode(result), isNot(identityHashCode(ref)));
+    });
+  });
+
+  group('#limitIfNotNull', () {
     test('should return the original query when null', () {
       final result = ref.filterIfNotNull(null);
 

--- a/packages/firefuel/test/src/utils/query_extensions_test.dart
+++ b/packages/firefuel/test/src/utils/query_extensions_test.dart
@@ -53,4 +53,18 @@ void main() {
       expect(identityHashCode(result), isNot(identityHashCode(ref)));
     });
   });
+
+  group('#orderIfNotNull', () {
+    test('should return the original query when null', () {
+      final result = ref.filterIfNotNull(null);
+
+      expect(identityHashCode(result), identityHashCode(ref));
+    });
+
+    test('should return a new query when not null', () async {
+      final result = ref.orderIfNotNull(TestUser.fieldName);
+
+      expect(identityHashCode(result), isNot(identityHashCode(ref)));
+    });
+  });
 }

--- a/packages/firefuel/test/src/utils/query_extensions_test.dart
+++ b/packages/firefuel/test/src/utils/query_extensions_test.dart
@@ -6,11 +6,13 @@ import '../../utils/test_user.dart';
 import '../firefuel_collection_test.dart';
 
 void main() {
+  late TestCollection testCollection;
   late CollectionReference<TestUser?> ref;
 
   setUp(() {
     Firefuel.initialize(FakeFirebaseFirestore());
-    ref = TestCollection().ref;
+    testCollection = TestCollection();
+    ref = testCollection.ref;
   });
 
   group('#filterIfNotNull', () {
@@ -30,6 +32,23 @@ void main() {
       final result = ref.filterIfNotNull(
         [Clause(TestUser.fieldName, isEqualTo: 'testUser')],
       );
+
+      expect(identityHashCode(result), isNot(identityHashCode(ref)));
+    });
+  });
+
+  group('#startAfterIfNotNull', () {
+    test('should return the original query when null', () {
+      final result = ref.filterIfNotNull(null);
+
+      expect(identityHashCode(result), identityHashCode(ref));
+    });
+
+    test('should return a new query when not null', () async {
+      final defaultUser = TestUser('testUser');
+      final docId = await testCollection.create(defaultUser);
+      final documentSnapshot = await testCollection.ref.doc(docId.docId).get();
+      final result = ref.startAfterIfNotNull(documentSnapshot);
 
       expect(identityHashCode(result), isNot(identityHashCode(ref)));
     });

--- a/packages/firefuel/test/src/utils/query_extensions_test.dart
+++ b/packages/firefuel/test/src/utils/query_extensions_test.dart
@@ -1,0 +1,37 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firefuel/firefuel.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../utils/test_user.dart';
+import '../firefuel_collection_test.dart';
+
+void main() {
+  late CollectionReference<TestUser?> ref;
+
+  setUp(() {
+    Firefuel.initialize(FakeFirebaseFirestore());
+    ref = TestCollection().ref;
+  });
+
+  group('#filterIfNotNull', () {
+    test('should return the original query when null', () {
+      final result = ref.filterIfNotNull(null);
+
+      expect(identityHashCode(result), identityHashCode(ref));
+    });
+
+    test('should return the original query when empty', () {
+      final result = ref.filterIfNotNull([]);
+
+      expect(identityHashCode(result), identityHashCode(ref));
+    });
+
+    test('should return a new query when not null', () {
+      final result = ref.filterIfNotNull(
+        [Clause(TestUser.fieldName, isEqualTo: 'testUser')],
+      );
+
+      expect(identityHashCode(result), isNot(identityHashCode(ref)));
+    });
+  });
+}

--- a/packages/firefuel/test/src/utils/query_extensions_test.dart
+++ b/packages/firefuel/test/src/utils/query_extensions_test.dart
@@ -70,13 +70,13 @@ void main() {
 
   group('#limitIfNotNull', () {
     test('should return the original query when null', () {
-      final result = ref.filterIfNotNull(null);
+      final result = ref.limitIfNotNull(null);
 
       expect(identityHashCode(result), identityHashCode(ref));
     });
 
     test('should return a new query when not null', () async {
-      final result = ref.orderIfNotNull(TestUser.fieldName);
+      final result = ref.limitIfNotNull(10);
 
       expect(identityHashCode(result), isNot(identityHashCode(ref)));
     });


### PR DESCRIPTION
Resolves #26 

### Reason for Change
Users need the ability to paginate their collections

### Proposed Changes
- Create a `Chunk` class that contains all the information necessary to start, continue, and end pagination of the collection
- Add a `paginate` method that returns a `Chunk` to be passed back in when needed
- Pass through to repo

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


### Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Readme Updated
- [ ] Example project updated
- [x] Tests added/updated
- [ ] Changelog updated
- [ ] Pubspec version updated
