### PR TITLE
feat: Create #readAll

### DIFF
--- a/packages/firefuel/lib/src/firefuel_collection.dart
+++ b/packages/firefuel/lib/src/firefuel_collection.dart
@@ -135,6 +135,13 @@ abstract class FirefuelCollection<T extends Serializable>
   }
 
   @override
+  Future<List<T>> readAll() async {
+    final snapshot = await ref.get();
+
+    return snapshot.docs.toListT();
+  }
+
+  @override
   Future<T> readOrCreate({
     required DocumentId docId,
     required T createValue,

--- a/packages/firefuel/lib/src/firefuel_repository.dart
+++ b/packages/firefuel/lib/src/firefuel_repository.dart
@@ -65,6 +65,11 @@ abstract class FirefuelRepository<T extends Serializable>
   }
 
   @override
+  Future<Either<Failure, List<T>>> readAll() async {
+    return guard(() => _collection.readAll());
+  }
+
+  @override
   Future<Either<Failure, T>> readOrCreate({
     required DocumentId docId,
     required T createValue,

--- a/packages/firefuel/lib/src/rules.dart
+++ b/packages/firefuel/lib/src/rules.dart
@@ -49,7 +49,14 @@ abstract class CollectionRead<R, T extends Serializable> {
   /// throws a [MissingValueException] when no [Clause]s are given
   Stream<R> listenWhere(List<Clause> clauses, {int? limit});
 
-  /// Gets a list of all documents from the collection as a list
+  /// Gets all documents from the collection
+  ///
+  /// Does NOT refresh automatically
+  ///
+  /// Related: [listenAll]
+  ///
+  /// {@macro firefuel.rules.subclasses}
+  /// {@macro firefuel.rules.implementations}
   Future<R> readAll();
 }
 

--- a/packages/firefuel/lib/src/rules.dart
+++ b/packages/firefuel/lib/src/rules.dart
@@ -48,6 +48,9 @@ abstract class CollectionRead<R, T extends Serializable> {
   ///
   /// throws a [MissingValueException] when no [Clause]s are given
   Stream<R> listenWhere(List<Clause> clauses, {int? limit});
+
+  /// Gets a list of all documents from the collection as a list
+  Future<R> readAll();
 }
 
 /// Get a number of Documents from the Collection

--- a/packages/firefuel/test/mocks/mock_collection.dart
+++ b/packages/firefuel/test/mocks/mock_collection.dart
@@ -21,6 +21,7 @@ extension MockCollectionX<T extends Serializable> on MockCollection<T> {
     Stream<List<T>> Function()? onListenWhere,
     Chunk<T> Function()? onPaginate,
     T? Function()? onRead,
+    List<T>? Function()? onReadAll,
     T Function()? onReadOrCreate,
     Null Function()? onReplace,
     Null Function()? onReplaceFields,
@@ -79,6 +80,10 @@ extension MockCollectionX<T extends Serializable> on MockCollection<T> {
 
     if (onRead != null) {
       when(() => read(any())).thenAnswer((_) => Future.value(onRead()));
+    }
+
+    if (onReadAll != null) {
+      when(() => readAll()).thenAnswer((_) => Future.value(onReadAll()));
     }
 
     if (onReadOrCreate != null) {

--- a/packages/firefuel/test/src/firefuel_collection_test.dart
+++ b/packages/firefuel/test/src/firefuel_collection_test.dart
@@ -405,6 +405,29 @@ void main() {
     });
   });
 
+  group('#readAll', () {
+    final expectedUser1 = TestUser('expectedUser');
+    final expectedUser2 = TestUser('expectedUser');
+    final expectedUser3 = TestUser('expectedUser');
+    final userList = [expectedUser1, expectedUser2, expectedUser3];
+
+    test('should return all items', () async {
+      await testCollection.create(expectedUser1);
+      await testCollection.create(expectedUser2);
+      await testCollection.create(expectedUser3);
+
+      final readResult = await testCollection.readAll();
+
+      expect(readResult, userList);
+    });
+
+    test('should return emtpy list when no items in collection', () async {
+      final readResult = await testCollection.readAll();
+
+      expect(readResult, []);
+    });
+  });
+
   group('#readOrCreate', () {
     final documentId = DocumentId('testName');
 

--- a/packages/firefuel/test/src/firefuel_repository_test.dart
+++ b/packages/firefuel/test/src/firefuel_repository_test.dart
@@ -195,6 +195,18 @@ void main() {
     methodCallback: (testRepository) => testRepository.read(docId),
   );
 
+  RepositoryTestUtil.runTests<List<TestUser>, TestUser>(
+    methodName: 'readAll',
+    mockCollection: MockCollection(),
+    initHappyPath: (mockCollection) async {
+      mockCollection.initialize(onReadAll: () => [defaultUser]);
+    },
+    initSadPath: (mockCollection) async {
+      mockCollection.initialize(onReadAll: () => throw ExpectedFailure());
+    },
+    methodCallback: (testRepository) => testRepository.readAll(),
+  );
+
   RepositoryTestUtil.runTests<TestUser, TestUser>(
     methodName: 'readOrCreate',
     mockCollection: MockCollection(),


### PR DESCRIPTION
[Project Card Link](https://github.com/SupposedlySam/firefuel/issues/17)

### Reason for Change
There wasn't a readAll, which retrieves all docs from a collection.

### Proposed Changes
Create a new method called `readAll`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


### Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Readme Updated
- [ ] Example project updated
- [x] Tests added/updated
- [ ] Changelog updated
- [ ] Pubspec version updated
