### PR TITLE
refactor: rename listen to stream

### DIFF
--- a/packages/firefuel/lib/src/collection.dart
+++ b/packages/firefuel/lib/src/collection.dart
@@ -13,6 +13,4 @@ abstract class Collection<T extends Serializable>
   const Collection();
 
   CollectionReference<T?> get ref;
-
-  Stream<List<T>> get stream;
 }

--- a/packages/firefuel/lib/src/firefuel_collection.dart
+++ b/packages/firefuel/lib/src/firefuel_collection.dart
@@ -25,9 +25,6 @@ abstract class FirefuelCollection<T extends Serializable>
     );
   }
 
-  @override
-  Stream<List<T>> get stream => listenAll();
-
   CollectionReference<Map<String, dynamic>> get untypedRef {
     return firestore.collection(path);
   }
@@ -70,27 +67,27 @@ abstract class FirefuelCollection<T extends Serializable>
   }
 
   @override
-  Stream<T?> listen(DocumentId docId) {
+  Stream<T?> stream(DocumentId docId) {
     return ref.doc(docId.docId).snapshots().toMaybeT();
   }
 
   @override
-  Stream<List<T>> listenAll() {
+  Stream<List<T>> streamAll() {
     return ref.snapshots().toListT();
   }
 
   @override
-  Stream<List<T>> listenLimited(int limit) {
+  Stream<List<T>> streamLimited(int limit) {
     return ref.limit(limit).snapshots().toListT();
   }
 
   @override
-  Stream<List<T>> listenOrdered(List<OrderBy> orderBy) {
+  Stream<List<T>> streamOrdered(List<OrderBy> orderBy) {
     return ref.sort(orderBy).snapshots().toListT();
   }
 
   @override
-  Stream<List<T>> listenWhere(
+  Stream<List<T>> streamWhere(
     List<Clause> clauses, {
     List<OrderBy>? orderBy,
     int? limit,

--- a/packages/firefuel/lib/src/firefuel_repository.dart
+++ b/packages/firefuel/lib/src/firefuel_repository.dart
@@ -32,32 +32,32 @@ abstract class FirefuelRepository<T extends Serializable>
   }
 
   @override
-  Stream<Either<Failure, T?>> listen(DocumentId docId) {
-    return guardStream(() => _collection.listen(docId));
+  Stream<Either<Failure, T?>> stream(DocumentId docId) {
+    return guardStream(() => _collection.stream(docId));
   }
 
   @override
-  Stream<Either<Failure, List<T>>> listenAll() {
-    return guardStream(() => _collection.listenAll());
+  Stream<Either<Failure, List<T>>> streamAll() {
+    return guardStream(() => _collection.streamAll());
   }
 
   @override
-  Stream<Either<Failure, List<T>>> listenLimited(int limit) {
-    return guardStream(() => _collection.listenLimited(limit));
+  Stream<Either<Failure, List<T>>> streamLimited(int limit) {
+    return guardStream(() => _collection.streamLimited(limit));
   }
 
   @override
-  Stream<Either<Failure, List<T>>> listenOrdered(List<OrderBy> orderBy) {
-    return guardStream(() => _collection.listenOrdered(orderBy));
+  Stream<Either<Failure, List<T>>> streamOrdered(List<OrderBy> orderBy) {
+    return guardStream(() => _collection.streamOrdered(orderBy));
   }
 
   @override
-  Stream<Either<Failure, List<T>>> listenWhere(
+  Stream<Either<Failure, List<T>>> streamWhere(
     List<Clause> clauses, {
     List<OrderBy>? orderBy,
     int? limit,
   }) {
-    return guardStream(() => _collection.listenWhere(clauses, limit: limit));
+    return guardStream(() => _collection.streamWhere(clauses, limit: limit));
   }
 
   @override

--- a/packages/firefuel/lib/src/rules.dart
+++ b/packages/firefuel/lib/src/rules.dart
@@ -19,7 +19,7 @@ abstract class CollectionRead<R, T extends Serializable> {
   /// Refreshes automatically when new data is added/removed from the collection
   ///
   /// See: StreamBuilder
-  Stream<R> listenAll();
+  Stream<R> streamAll();
 
   /// Get up to the maximum number of documents specified by the [limit]
   ///
@@ -30,7 +30,7 @@ abstract class CollectionRead<R, T extends Serializable> {
   ///
   /// Refreshes automatically when new data is added/removed from the
   /// collection
-  Stream<R> listenLimited(int limit);
+  Stream<R> streamLimited(int limit);
 
   /// Get a list of all documents from the collection sorted by [orderBy]
   ///
@@ -38,7 +38,7 @@ abstract class CollectionRead<R, T extends Serializable> {
   /// collection
   ///
   /// throws a [MissingValueException] when no [orderBy]s are given
-  Stream<R> listenOrdered(List<OrderBy> orderBy);
+  Stream<R> streamOrdered(List<OrderBy> orderBy);
 
   /// Get a list of documents matching all clauses
   ///
@@ -73,7 +73,7 @@ abstract class CollectionRead<R, T extends Serializable> {
   /// throws a [MoreThanOneFieldInRangeClauseException] when range filters are
   /// on different fields
   /// {@endtemplate}
-  Stream<R> listenWhere(
+  Stream<R> streamWhere(
     List<Clause> clauses, {
     List<OrderBy>? orderBy,
     int? limit,
@@ -90,7 +90,7 @@ abstract class CollectionRead<R, T extends Serializable> {
   ///
   /// Does NOT refresh automatically
   ///
-  /// Related: [listenAll]
+  /// Related: [streamAll]
   ///
   /// {@macro firefuel.rules.subclasses}
   /// {@macro firefuel.rules.implementations}
@@ -195,7 +195,7 @@ abstract class DocDelete<R> {
 /// {@macro firefuel.rules.implementations}
 abstract class DocRead<R> {
   /// Gets a stream of the document requested
-  Stream<R> listen(DocumentId docId);
+  Stream<R> stream(DocumentId docId);
 
   /// Gets a single document from the collection
   ///

--- a/packages/firefuel/test/mocks/mock_collection.dart
+++ b/packages/firefuel/test/mocks/mock_collection.dart
@@ -15,11 +15,11 @@ extension MockCollectionX<T extends Serializable> on MockCollection<T> {
     DocumentId Function()? onCreateById,
     Null Function()? onDelete,
     List<T> Function()? onLimit,
-    Stream<T?> Function()? onListen,
-    Stream<List<T>> Function()? onListenAll,
-    Stream<List<T>> Function()? onListenLimited,
-    Stream<List<T>> Function()? onListenOrdered,
-    Stream<List<T>> Function()? onListenWhere,
+    Stream<T?> Function()? onStream,
+    Stream<List<T>> Function()? onStreamAll,
+    Stream<List<T>> Function()? onStreamLimited,
+    Stream<List<T>> Function()? onStreamOrdered,
+    Stream<List<T>> Function()? onStreamWhere,
     List<T> Function()? onOrderBy,
     Chunk<T> Function()? onPaginate,
     T? Function()? onRead,
@@ -58,31 +58,31 @@ extension MockCollectionX<T extends Serializable> on MockCollection<T> {
       when(() => limit(any())).thenAnswer((_) => Future.value(onLimit()));
     }
 
-    if (onListen != null) {
-      when(() => listen(any())).thenAnswer((_) => onListen());
+    if (onStream != null) {
+      when(() => stream(any())).thenAnswer((_) => onStream());
     }
 
-    if (onListenAll != null) {
-      when(() => listenAll()).thenAnswer((_) => onListenAll());
+    if (onStreamAll != null) {
+      when(() => streamAll()).thenAnswer((_) => onStreamAll());
     }
 
-    if (onListenLimited != null) {
-      when(() => listenLimited(any())).thenAnswer((_) => onListenLimited());
+    if (onStreamLimited != null) {
+      when(() => streamLimited(any())).thenAnswer((_) => onStreamLimited());
     }
 
-    if (onListenOrdered != null) {
-      when(() => listenOrdered(any())).thenAnswer((_) => onListenOrdered());
+    if (onStreamOrdered != null) {
+      when(() => streamOrdered(any())).thenAnswer((_) => onStreamOrdered());
     }
 
-    if (onListenWhere != null) {
+    if (onStreamWhere != null) {
       when(() {
-        return listenWhere(
+        return streamWhere(
           any(),
           orderBy: any(named: 'orderBy'),
           limit: any(named: 'limit'),
         );
       }).thenAnswer(
-        (_) => onListenWhere(),
+        (_) => onStreamWhere(),
       );
     }
 

--- a/packages/firefuel/test/src/firefuel_collection_test.dart
+++ b/packages/firefuel/test/src/firefuel_collection_test.dart
@@ -213,14 +213,14 @@ void main() {
     );
   });
 
-  group('#listen', () {
+  group('#stream', () {
     late Stream<TestUser?> stream;
     late DocumentId docId;
 
     setUp(() async {
       docId = await testCollection.create(defaultUser);
 
-      stream = testCollection.listen(docId);
+      stream = testCollection.stream(docId);
     });
 
     test('should output new value when doc updates', () async {
@@ -245,7 +245,7 @@ void main() {
     });
   });
 
-  group('#listenAll', () {
+  group('#streamAll', () {
     late Stream<List<TestUser>> stream;
     late DocumentId docId;
     final newUser1 = TestUser('newUser1');
@@ -255,7 +255,7 @@ void main() {
       docId = await testCollection.create(defaultUser);
       await testCollection.create(newUser1);
 
-      stream = testCollection.listenAll();
+      stream = testCollection.streamAll();
     });
 
     test('should update when an item is added', () async {
@@ -282,7 +282,7 @@ void main() {
     });
   });
 
-  group('#listenLimited', () {
+  group('#streamLimited', () {
     setUp(() async {
       await testCollection.create(defaultUser);
       await testCollection.create(defaultUser);
@@ -290,7 +290,7 @@ void main() {
     });
 
     test('when items are less than limit, should return all items', () {
-      final stream = testCollection.listenLimited(4);
+      final stream = testCollection.streamLimited(4);
 
       expect(
         stream,
@@ -303,7 +303,7 @@ void main() {
     test(
       'when items are greater than limit, should return items up to limit',
       () {
-        final stream = testCollection.listenLimited(2);
+        final stream = testCollection.streamLimited(2);
 
         expect(
           stream,
@@ -317,7 +317,7 @@ void main() {
     test(
       'when items are equal to limit, should return all items',
       () {
-        final stream = testCollection.listenLimited(3);
+        final stream = testCollection.streamLimited(3);
 
         expect(
           stream,
@@ -329,7 +329,7 @@ void main() {
     );
   });
 
-  group('#listenOrdered', () {
+  group('#streamOrdered', () {
     late Stream<List<TestUser>> stream;
     late DocumentId docId;
     final newUser1 = TestUser('Alfred');
@@ -341,7 +341,7 @@ void main() {
       await testCollection.create(newUser3);
 
       stream =
-          testCollection.listenOrdered([OrderBy(field: TestUser.fieldName)]);
+          testCollection.streamOrdered([OrderBy(field: TestUser.fieldName)]);
     });
 
     test('should return an ordered list', () async {
@@ -379,7 +379,7 @@ void main() {
     });
   });
 
-  group('#listenWhere', () {
+  group('#streamWhere', () {
     const String expectedName = 'expectedName';
     final expectedUser = TestUser(expectedName);
 
@@ -394,7 +394,7 @@ void main() {
       });
 
       test('should return a subset of the existing list', () {
-        final filteredStream = testCollection.listenWhere(
+        final filteredStream = testCollection.streamWhere(
           [Clause(TestUser.fieldName, isEqualTo: expectedName)],
         );
 
@@ -407,7 +407,7 @@ void main() {
       });
 
       test('should return a subset based on multiple clauses', () {
-        final filteredStream = testCollection.listenWhere(
+        final filteredStream = testCollection.streamWhere(
           [
             Clause(TestUser.fieldName, isNotEqualTo: unexpectedName1),
             Clause(TestUser.fieldName, isNotEqualTo: unexpectedName2),
@@ -424,7 +424,7 @@ void main() {
 
       test('should throw $MissingValueException when no clauses are given', () {
         expect(
-          () => testCollection.listenWhere([]),
+          () => testCollection.streamWhere([]),
           throwsA(isA<MissingValueException>()),
         );
       });
@@ -433,7 +433,7 @@ void main() {
         'should throw $MoreThanOneFieldInRangeClauseException when more than one field is used in multiple range clauses',
         () {
           expect(
-            () => testCollection.listenWhere([
+            () => testCollection.streamWhere([
               Clause('firstField', isGreaterThan: 44),
               Clause('secondField', isLessThan: 22)
             ]),
@@ -450,7 +450,7 @@ void main() {
         await testCollection.create(expectedUser);
         await testCollection.create(expectedUser);
 
-        final limitedStream = testCollection.listenWhere(
+        final limitedStream = testCollection.streamWhere(
           [Clause(TestUser.fieldName, isEqualTo: expectedName)],
           limit: 1,
         );
@@ -833,7 +833,7 @@ void main() {
         'should throw $MoreThanOneFieldInRangeClauseException when more than one field is used in multiple range clauses',
         () {
           expect(
-            () => testCollection.listenWhere([
+            () => testCollection.streamWhere([
               Clause('firstField', isGreaterThan: 44),
               Clause('secondField', isLessThan: 22)
             ]),

--- a/packages/firefuel/test/src/firefuel_repository_test.dart
+++ b/packages/firefuel/test/src/firefuel_repository_test.dart
@@ -66,74 +66,74 @@ void main() {
   );
 
   RepositoryTestUtil.runStreamTests<TestUser?, TestUser>(
-    methodName: 'listen',
+    methodName: 'stream',
     mockCollection: MockCollection(),
     initHappyPath: (mockCollection) async {
       mockCollection.initialize(
-        onListen: () => Stream.fromIterable([TestUser('streamUser')]),
+        onStream: () => Stream.fromIterable([TestUser('streamUser')]),
       );
     },
     initSadPath: (mockCollection) async {
-      mockCollection.initialize(onListen: () => throw ExpectedFailure());
+      mockCollection.initialize(onStream: () => throw ExpectedFailure());
     },
-    streamCallback: (testRepository) => testRepository.listen(docId),
+    streamCallback: (testRepository) => testRepository.stream(docId),
   );
 
   RepositoryTestUtil.runStreamTests<List<TestUser>, TestUser>(
-    methodName: 'listenAll',
+    methodName: 'streamAll',
     mockCollection: MockCollection(),
     initHappyPath: (mockCollection) async {
       mockCollection.initialize(
-        onListenAll: () => Stream.fromIterable([
+        onStreamAll: () => Stream.fromIterable([
           [TestUser('streamUser')]
         ]),
       );
     },
     initSadPath: (mockCollection) async {
-      mockCollection.initialize(onListenAll: () => throw ExpectedFailure());
+      mockCollection.initialize(onStreamAll: () => throw ExpectedFailure());
     },
-    streamCallback: (testRepository) => testRepository.listenAll(),
+    streamCallback: (testRepository) => testRepository.streamAll(),
   );
 
   RepositoryTestUtil.runStreamTests<List<TestUser>, TestUser>(
-    methodName: 'listenLimited',
+    methodName: 'streamLimited',
     mockCollection: MockCollection(),
     initHappyPath: (mockCollection) async {
       mockCollection.initialize(
-        onListenLimited: () => Stream.fromIterable([
+        onStreamLimited: () => Stream.fromIterable([
           [TestUser('streamUser')]
         ]),
       );
     },
     initSadPath: (mockCollection) async {
-      mockCollection.initialize(onListenLimited: () => throw ExpectedFailure());
+      mockCollection.initialize(onStreamLimited: () => throw ExpectedFailure());
     },
-    streamCallback: (testRepository) => testRepository.listenLimited(1),
+    streamCallback: (testRepository) => testRepository.streamLimited(1),
   );
 
   RepositoryTestUtil.runStreamTests<List<TestUser>, TestUser>(
-    methodName: 'listenOrdered',
+    methodName: 'streamOrdered',
     mockCollection: MockCollection(),
     initHappyPath: (mockCollection) async {
       mockCollection.initialize(
-        onListenOrdered: () => Stream.fromIterable([
+        onStreamOrdered: () => Stream.fromIterable([
           [TestUser('streamUser')]
         ]),
       );
     },
     initSadPath: (mockCollection) async {
-      mockCollection.initialize(onListenOrdered: () => throw ExpectedFailure());
+      mockCollection.initialize(onStreamOrdered: () => throw ExpectedFailure());
     },
     streamCallback: (testRepository) =>
-        testRepository.listenOrdered([OrderBy(field: TestUser.fieldName)]),
+        testRepository.streamOrdered([OrderBy(field: TestUser.fieldName)]),
   );
 
   RepositoryTestUtil.runStreamTests<List<TestUser>, TestUser>(
-    methodName: 'listenWhere(limit:null)',
+    methodName: 'streamWhere(limit:null)',
     mockCollection: MockCollection(),
     initHappyPath: (mockCollection) async {
       mockCollection.initialize(
-        onListenWhere: () => Stream.fromIterable(
+        onStreamWhere: () => Stream.fromIterable(
           [
             [
               TestUser('unexpectedUser1'),
@@ -145,21 +145,21 @@ void main() {
       );
     },
     initSadPath: (mockCollection) async {
-      mockCollection.initialize(onListenWhere: () => throw ExpectedFailure());
+      mockCollection.initialize(onStreamWhere: () => throw ExpectedFailure());
     },
     streamCallback: (testRepository) {
-      return testRepository.listenWhere([
+      return testRepository.streamWhere([
         Clause(TestUser.fieldName, isEqualTo: 'expectedUser'),
       ]);
     },
   );
 
   RepositoryTestUtil.runStreamTests<List<TestUser>, TestUser>(
-    methodName: 'listenWhere(limit:1)',
+    methodName: 'streamWhere(limit:1)',
     mockCollection: MockCollection(),
     initHappyPath: (mockCollection) async {
       mockCollection.initialize(
-        onListenWhere: () => Stream.fromIterable(
+        onStreamWhere: () => Stream.fromIterable(
           [
             [
               TestUser('unexpectedUser1'),
@@ -172,10 +172,10 @@ void main() {
       );
     },
     initSadPath: (mockCollection) async {
-      mockCollection.initialize(onListenWhere: () => throw ExpectedFailure());
+      mockCollection.initialize(onStreamWhere: () => throw ExpectedFailure());
     },
     streamCallback: (testRepository) {
-      return testRepository.listenWhere(
+      return testRepository.streamWhere(
         [Clause(TestUser.fieldName, isEqualTo: 'expectedUser')],
         limit: 1,
       );
@@ -183,11 +183,11 @@ void main() {
   );
 
   RepositoryTestUtil.runStreamTests<List<TestUser>, TestUser>(
-    methodName: 'listenWhere(orderBy:{value})',
+    methodName: 'streamWhere(orderBy:{value})',
     mockCollection: MockCollection(),
     initHappyPath: (mockCollection) async {
       mockCollection.initialize(
-        onListenWhere: () => Stream.fromIterable(
+        onStreamWhere: () => Stream.fromIterable(
           [
             [
               TestUser('unexpectedUser1'),
@@ -200,10 +200,10 @@ void main() {
       );
     },
     initSadPath: (mockCollection) async {
-      mockCollection.initialize(onListenWhere: () => throw ExpectedFailure());
+      mockCollection.initialize(onStreamWhere: () => throw ExpectedFailure());
     },
     streamCallback: (testRepository) {
-      return testRepository.listenWhere(
+      return testRepository.streamWhere(
         [Clause(TestUser.fieldName, isEqualTo: 'expectedUser')],
         orderBy: [OrderBy(field: TestUser.fieldName)],
       );


### PR DESCRIPTION
### Reason for Change
`stream` might be more common than `listen` 🤷 

### Proposed Changes
rename all `listen` methods to `stream`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


### Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Readme Updated
- [ ] Example project updated
- [x] Tests added/updated
- [ ] Changelog updated
- [ ] Pubspec version updated
