### PR TITLE
feat: Create generate document id

### DIFF
--- a/packages/firefuel/lib/src/firefuel_collection.dart
+++ b/packages/firefuel/lib/src/firefuel_collection.dart
@@ -17,6 +17,8 @@ abstract class FirefuelCollection<T extends Serializable>
     return path;
   }
 
+  DocumentId generateDocumentId() => DocumentId(ref.doc().id);
+
   @override
   CollectionReference<T?> get ref {
     return untypedRef.withConverter(

--- a/packages/firefuel/lib/src/firefuel_collection.dart
+++ b/packages/firefuel/lib/src/firefuel_collection.dart
@@ -280,6 +280,9 @@ abstract class FirefuelCollection<T extends Serializable>
         .limitIfNotNull(limit);
   }
 
+  /// Prefix the collection path with the environment
+  ///
+  /// if the environment isn't provided, the path is returned unaltered.
   static String _buildPath(String path, bool useEnv) {
     if (useEnv) return '${Firefuel.env}$path';
 

--- a/packages/firefuel/lib/src/firefuel_collection.dart
+++ b/packages/firefuel/lib/src/firefuel_collection.dart
@@ -17,7 +17,11 @@ abstract class FirefuelCollection<T extends Serializable>
     return path;
   }
 
-  DocumentId generateDocumentId() => DocumentId(ref.doc().id);
+  /// Auto-generate a [DocumentId]
+  ///
+  /// The unique key generated is prefixed with a client-generated timestamp
+  /// so that the resulting list will be chronologically-sorted.
+  DocumentId generateDocId() => DocumentId(ref.doc().id);
 
   @override
   CollectionReference<T?> get ref {

--- a/packages/firefuel/lib/src/firefuel_collection.dart
+++ b/packages/firefuel/lib/src/firefuel_collection.dart
@@ -11,18 +11,6 @@ abstract class FirefuelCollection<T extends Serializable>
   FirefuelCollection(String path, {bool useEnv = true})
       : this.path = _buildPath(path, useEnv);
 
-  static String _buildPath(String path, bool useEnv) {
-    if (useEnv) return '${Firefuel.env}$path';
-
-    return path;
-  }
-
-  /// Auto-generate a [DocumentId]
-  ///
-  /// The unique key generated is prefixed with a client-generated timestamp
-  /// so that the resulting list will be chronologically-sorted.
-  DocumentId generateDocId() => DocumentId(ref.doc().id);
-
   @override
   CollectionReference<T?> get ref {
     return untypedRef.withConverter(
@@ -65,46 +53,17 @@ abstract class FirefuelCollection<T extends Serializable>
     SnapshotOptions? options,
   );
 
+  /// Auto-generate a [DocumentId]
+  ///
+  /// The unique key generated is prefixed with a client-generated timestamp
+  /// so that the resulting list will be chronologically-sorted.
+  DocumentId generateDocId() => DocumentId(ref.doc().id);
+
   @override
   Future<List<T>> limit(int limit) async {
     final snapshot = await ref.limit(limit).get();
 
     return snapshot.docs.toListT();
-  }
-
-  @override
-  Stream<T?> stream(DocumentId docId) {
-    return ref.doc(docId.docId).snapshots().toMaybeT();
-  }
-
-  @override
-  Stream<List<T>> streamAll() {
-    return ref.snapshots().toListT();
-  }
-
-  @override
-  Stream<List<T>> streamLimited(int limit) {
-    return ref.limit(limit).snapshots().toListT();
-  }
-
-  @override
-  Stream<List<T>> streamOrdered(List<OrderBy> orderBy) {
-    return ref.sort(orderBy).snapshots().toListT();
-  }
-
-  @override
-  Stream<List<T>> streamWhere(
-    List<Clause> clauses, {
-    List<OrderBy>? orderBy,
-    int? limit,
-  }) {
-    final query = _getWhereWithOrderByAndLimitQuery(
-      clauses: clauses,
-      orderBy: orderBy,
-      limit: limit,
-    );
-
-    return query.snapshots().toListT();
   }
 
   @override
@@ -139,20 +98,6 @@ abstract class FirefuelCollection<T extends Serializable>
             cursor: cursor,
             orderBy: chunk.orderBy,
           );
-  }
-
-  /// Get the Documents used to create a [Chunk] when paginating data from a
-  /// Collection
-  ///
-  /// Orders and limits the [ref] and returns the [QuerySnapshot]
-  Future<QuerySnapshot<T?>> _buildPaginationSnapshot(Chunk<T> chunk) async {
-    var query = ref
-        .filterIfNotNull(chunk.clauses)
-        .sortIfNotNull(chunk.orderBy)
-        .startAfterIfNotNull(chunk.cursor)
-        .limitIfNotNull(chunk.limit);
-
-    return query.get();
   }
 
   @override
@@ -214,6 +159,41 @@ abstract class FirefuelCollection<T extends Serializable>
     return null;
   }
 
+  @override
+  Stream<T?> stream(DocumentId docId) {
+    return ref.doc(docId.docId).snapshots().toMaybeT();
+  }
+
+  @override
+  Stream<List<T>> streamAll() {
+    return ref.snapshots().toListT();
+  }
+
+  @override
+  Stream<List<T>> streamLimited(int limit) {
+    return ref.limit(limit).snapshots().toListT();
+  }
+
+  @override
+  Stream<List<T>> streamOrdered(List<OrderBy> orderBy) {
+    return ref.sort(orderBy).snapshots().toListT();
+  }
+
+  @override
+  Stream<List<T>> streamWhere(
+    List<Clause> clauses, {
+    List<OrderBy>? orderBy,
+    int? limit,
+  }) {
+    final query = _getWhereWithOrderByAndLimitQuery(
+      clauses: clauses,
+      orderBy: orderBy,
+      limit: limit,
+    );
+
+    return query.snapshots().toListT();
+  }
+
   /// Converts a [T?] to a [Map<String, Object?>] to upload to Firestore.
   Map<String, Object?> toFirestore(
     T? model,
@@ -257,6 +237,20 @@ abstract class FirefuelCollection<T extends Serializable>
     return snapshot.docs.toListT();
   }
 
+  /// Get the Documents used to create a [Chunk] when paginating data from a
+  /// Collection
+  ///
+  /// Orders and limits the [ref] and returns the [QuerySnapshot]
+  Future<QuerySnapshot<T?>> _buildPaginationSnapshot(Chunk<T> chunk) async {
+    var query = ref
+        .filterIfNotNull(chunk.clauses)
+        .sortIfNotNull(chunk.orderBy)
+        .startAfterIfNotNull(chunk.cursor)
+        .limitIfNotNull(chunk.limit);
+
+    return query.get();
+  }
+
   Query<T?> _getWhereWithOrderByAndLimitQuery({
     required List<Clause> clauses,
     required List<OrderBy>? orderBy,
@@ -284,5 +278,11 @@ abstract class FirefuelCollection<T extends Serializable>
         .filter(clauses)
         .sortIfNotNull(processedOrderBys)
         .limitIfNotNull(limit);
+  }
+
+  static String _buildPath(String path, bool useEnv) {
+    if (useEnv) return '${Firefuel.env}$path';
+
+    return path;
   }
 }

--- a/packages/firefuel/lib/src/firefuel_collection.dart
+++ b/packages/firefuel/lib/src/firefuel_collection.dart
@@ -251,6 +251,7 @@ abstract class FirefuelCollection<T extends Serializable>
     return query.get();
   }
 
+  // Creates a query to filter, sort, and limit the collection
   Query<T?> _getWhereWithOrderByAndLimitQuery({
     required List<Clause> clauses,
     required List<OrderBy>? orderBy,

--- a/packages/firefuel/test/src/firefuel_collection_test.dart
+++ b/packages/firefuel/test/src/firefuel_collection_test.dart
@@ -80,6 +80,15 @@ void main() {
     });
   });
 
+  group('#generateDocId', () {
+    test('should create a new id with each call', () {
+      final docId1 = testCollection.generateDocId();
+      final docId2 = testCollection.generateDocId();
+
+      expect(docId1, isNot(docId2));
+    });
+  });
+
   group('#limit', () {
     setUp(() async {
       await testCollection.create(defaultUser);


### PR DESCRIPTION
[Project Card Link](https://github.com/SupposedlySam/firefuel/issues/46)

Resolves Issue #46 

### Reason for Change
The only way to create a document id is by calling `collection.ref.doc().id`. This can get kinda lengthy.

### Proposed Changes
Create a `generateDocumentId` method that will return unique `DocumentId` 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


### Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Readme Updated
- [ ] Example project updated
- [ ] Tests added/updated
- [ ] Changelog updated
- [ ] Pubspec version updated
