### PR TITLE
feat: [package:firefuel] add universal io to support web

### DIFF
--- a/packages/firefuel/lib/src/utils/file_path_util.dart
+++ b/packages/firefuel/lib/src/utils/file_path_util.dart
@@ -1,4 +1,4 @@
-import 'dart:io';
+import 'package:universal_io/io.dart';
 
 class FilePathUtil {
   /// Provide a [Platform] agnostic file path

--- a/packages/firefuel/pubspec.lock
+++ b/packages/firefuel/pubspec.lock
@@ -441,6 +441,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  universal_io:
+    dependency: "direct main"
+    description:
+      name: universal_io
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
   vector_math:
     dependency: transitive
     description:

--- a/packages/firefuel/pubspec.yaml
+++ b/packages/firefuel/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   flutter:
     sdk: flutter
   stack_trace: ^1.10.0
+  universal_io: ^2.0.4
 
 dev_dependencies:
   fake_cloud_firestore: ^1.1.3

--- a/packages/firefuel/test/utils/fixture_reader.dart
+++ b/packages/firefuel/test/utils/fixture_reader.dart
@@ -1,5 +1,5 @@
 import 'dart:convert';
-import 'dart:io';
+import 'package:universal_io/io.dart';
 
 import '../utils/test_path.dart';
 

--- a/packages/firefuel/test/utils/test_path.dart
+++ b/packages/firefuel/test/utils/test_path.dart
@@ -2,7 +2,7 @@
 // Running unit tests via VSCode/Android studio has a slightly different working directory than unit tests invoked via 'flutter test' on the CLI
 // This script is a way to ensure that tests can be run via the CLI and in a given IDE.
 
-import 'dart:io';
+import 'package:universal_io/io.dart';
 
 import 'package:firefuel/src/utils/file_path_util.dart';
 


### PR DESCRIPTION
[Project Card Link](https://github.com/SupposedlySam/firefuel/projects/1#card-71865463)
Resolves #50 

### Reason for Change
Although we aren't using the FilePathUtil class, it was importing dart:io which isn't compatible on the web. Removing this should allow web support.

### Proposed Changes
Replace the import to dart:io with universal_io//io


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


### Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Readme Updated
- [ ] Example project updated
- [ ] Tests added/updated
- [ ] Changelog updated
- [ ] Pubspec version updated
