### PR TITLE
feat: [package:firefuel_core] add universal_io to support web

### DIFF
--- a/packages/firefuel_core/lib/src/failure.dart
+++ b/packages/firefuel_core/lib/src/failure.dart
@@ -1,4 +1,4 @@
-import 'dart:io';
+import 'package:universal_io/io.dart';
 
 import 'package:equatable/equatable.dart';
 import 'package:stack_trace/stack_trace.dart';

--- a/packages/firefuel_core/pubspec.lock
+++ b/packages/firefuel_core/pubspec.lock
@@ -309,6 +309,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  universal_io:
+    dependency: "direct main"
+    description:
+      name: universal_io
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
   vm_service:
     dependency: transitive
     description:

--- a/packages/firefuel_core/pubspec.yaml
+++ b/packages/firefuel_core/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   equatable: ^2.0.3
   stack_trace: ^1.10.0
+  universal_io: ^2.0.4
 
 dev_dependencies:
   test: ^1.17.11


### PR DESCRIPTION
[Project Card Link](https://github.com/SupposedlySam/firefuel/projects/1#card-71865463)
Resolves #50 

### Reason for Change
We are importing dart:io in the `Failure` class which isn't compatible with the web.  

### Proposed Changes
Depend on universal_io and switch out the import for dart:io

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


### Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Readme Updated
- [ ] Example project updated
- [ ] Tests added/updated
- [ ] Changelog updated
- [ ] Pubspec version updated
