### PR TITLE
fix: use stack trace from try failure

### DIFF
--- a/packages/firefuel/lib/src/firefuel_fetch_mixin.dart
+++ b/packages/firefuel/lib/src/firefuel_fetch_mixin.dart
@@ -20,7 +20,7 @@ mixin FirefuelFetchMixin {
       final result = await callback();
 
       return Right(result);
-    } catch (e) {
+    } catch (e, stack) {
       if (e is FormatException) {
         print('Format Exception: ${e.message}');
       }
@@ -28,7 +28,7 @@ mixin FirefuelFetchMixin {
       return Left(
         FirestoreFailure(
           error: e,
-          stackTrace: Chain.current(),
+          stackTrace: Chain.forTrace(stack),
         ),
       );
     }
@@ -47,7 +47,7 @@ mixin FirefuelFetchMixin {
       await for (var result in streamCallback()) {
         yield Right(result);
       }
-    } catch (e) {
+    } catch (e, stack) {
       if (e is FormatException) {
         print('Format Exception: ${e.message}');
       }
@@ -55,7 +55,7 @@ mixin FirefuelFetchMixin {
       yield Left(
         FirestoreFailure(
           error: e,
-          stackTrace: Chain.current(),
+          stackTrace: Chain.forTrace(stack),
         ),
       );
     }


### PR DESCRIPTION
### Reason for Change
We were incorrectly using the current stack trace inside of the catch rather than using the one passed to us from the actual failure

### Proposed Changes
Use the stack trace from the try to create a chain

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


### Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Readme Updated
- [ ] Example project updated
- [ ] Tests added/updated
- [ ] Changelog updated
- [ ] Pubspec version updated
