### PR TITLE
feat: add count, countWhere, streamCount, and streamCountWhere

### DIFF
--- a/packages/firefuel/CHANGELOG.md
+++ b/packages/firefuel/CHANGELOG.md
@@ -7,7 +7,7 @@ Adds `count` and `countWhere` to all `Collection`s:
 Uses the count feature introduced in v4.0.0 of `cloud_firestore` to count
 documents on the server without retrieving documents.
 
-> ## Firestore Release Notes
+> ## Firebase Release Notes
 >
 > Cloud Firestore now supports a count() aggregation query that allows you
 > to determine the number of documents in a collection. The server
@@ -16,6 +16,12 @@ documents on the server without retrieving documents.
 > transferred, compared to executing the full query.
 
 > Source: https://firebase.google.com/support/releases#firestore-count-queries
+
+---
+
+Adds `streamCount` and `streamCountWhere` to all `Collection`s:
+
+These methods DO NOT use the server side count function provided by v4.0.0 of `cloud_firestore` as they do not currenly support streams. These methods works by streaming documents from Firestore and accessing the size property once the full query is executed. This method will incur document reads and bytes transferred.
 
 ## 0.2.3
 

--- a/packages/firefuel/CHANGELOG.md
+++ b/packages/firefuel/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 0.3.0
+
+### Adds `count` method
+
+Adds `count` and `countWhere` to all `Collection`s:
+
+Uses the count feature introduced in v4.0.0 of `cloud_firestore` to count
+documents on the server without retrieving documents.
+
+> ## Firestore Release Notes
+>
+> Cloud Firestore now supports a count() aggregation query that allows you
+> to determine the number of documents in a collection. The server
+> calculates the count, and transmits only the result, a single integer,
+> back to your app, saving on both billed document reads and bytes
+> transferred, compared to executing the full query.
+
+> Source: https://firebase.google.com/support/releases#firestore-count-queries
+
 ## 0.2.3
 
 Our API has not changed so this is only a patch for `firefuel`. However, `cloud_firestore` and `firebase_core` both have breaking changes.

--- a/packages/firefuel/lib/src/collection.dart
+++ b/packages/firefuel/lib/src/collection.dart
@@ -3,7 +3,7 @@ import 'package:firefuel/firefuel.dart';
 abstract class Collection<T extends Serializable>
     implements
         CollectionPaginate<Chunk<T>, T>,
-        CollectionPrimitives,
+        CollectionPrimitives<int>,
         CollectionRead<List<T>, T>,
         DocCreate<DocumentId, T>,
         DocCreateIfNotExist<T, T>,

--- a/packages/firefuel/lib/src/collection.dart
+++ b/packages/firefuel/lib/src/collection.dart
@@ -2,8 +2,8 @@ import 'package:firefuel/firefuel.dart';
 
 abstract class Collection<T extends Serializable>
     implements
+        CollectionCount<int>,
         CollectionPaginate<Chunk<T>, T>,
-        CollectionPrimitives<int>,
         CollectionRead<List<T>, T>,
         DocCreate<DocumentId, T>,
         DocCreateIfNotExist<T, T>,

--- a/packages/firefuel/lib/src/collection.dart
+++ b/packages/firefuel/lib/src/collection.dart
@@ -2,8 +2,9 @@ import 'package:firefuel/firefuel.dart';
 
 abstract class Collection<T extends Serializable>
     implements
-        CollectionRead<List<T>, T>,
         CollectionPaginate<Chunk<T>, T>,
+        CollectionPrimitives,
+        CollectionRead<List<T>, T>,
         DocCreate<DocumentId, T>,
         DocCreateIfNotExist<T, T>,
         DocDelete<Null>,

--- a/packages/firefuel/lib/src/firefuel_collection.dart
+++ b/packages/firefuel/lib/src/firefuel_collection.dart
@@ -25,6 +25,20 @@ abstract class FirefuelCollection<T extends Serializable>
   }
 
   @override
+  Future<int> count() async {
+    final snapshot = await untypedRef.count().get();
+
+    return snapshot.count;
+  }
+
+  @override
+  Future<int> countWhere(List<Clause> clauses) async {
+    final snapshot = await untypedRef.filter(clauses).count().get();
+
+    return snapshot.count;
+  }
+
+  @override
   Future<DocumentId> create(T value) async {
     final documentRef = await ref.add(value);
 

--- a/packages/firefuel/lib/src/firefuel_collection.dart
+++ b/packages/firefuel/lib/src/firefuel_collection.dart
@@ -24,6 +24,23 @@ abstract class FirefuelCollection<T extends Serializable>
     return firestore.collection(path);
   }
 
+  /// {@macro firefuel.rules.count.definition}
+  ///
+  /// {@template firefuel.collection.count}
+  /// Uses the count feature introduced in v4.0.0 of `cloud_firestore` to count
+  /// documents on the server without retrieving documents.
+  ///
+  /// > ## Firestore Release Notes
+  /// > Cloud Firestore now supports a count() aggregation query that allows you
+  /// > to determine the number of documents in a collection. The server
+  /// > calculates the count, and transmits only the result, a single integer,
+  /// > back to your app, saving on both billed document reads and bytes
+  /// > transferred, compared to executing the full query.
+  ///
+  /// > Source: https://firebase.google.com/support/releases#firestore-count-queries
+  /// {@endtemplate}
+  ///
+  /// {@macro firefuel.rules.count.footer}
   @override
   Future<int> count() async {
     final snapshot = await untypedRef.count().get();
@@ -31,6 +48,11 @@ abstract class FirefuelCollection<T extends Serializable>
     return snapshot.count;
   }
 
+  /// {@macro firefuel.rules.countwhere.definition}
+  ///
+  /// {@macro firefuel.collection.count}
+  ///
+  /// {@macro firefuel.rules.countwhere.footer}
   @override
   Future<int> countWhere(List<Clause> clauses) async {
     final snapshot = await untypedRef.filter(clauses).count().get();
@@ -179,6 +201,43 @@ abstract class FirefuelCollection<T extends Serializable>
   @override
   Stream<List<T>> streamAll() {
     return ref.snapshots().toListT();
+  }
+
+  /// {@macro firefuel.rules.streamcount.definition}
+  ///
+  /// {@template firefuel.collection.streamcount}
+  /// This method DOES NOT use the server side count function provided by
+  /// v4.0.0 of `cloud_firestore` as they do not currenly support streams.
+  ///
+  /// See [count] and [countWhere] for more details.
+  ///
+  /// This method works by streaming documents from Firestore and accessing the
+  /// size property once the full query is executed. This method will incur
+  /// document reads and bytes transferred.
+  ///
+  /// As per the Google's recommendation, you shouldn't need to worry about
+  /// optimnizing for reads until it becomes a problem. Depending on the size of
+  /// your app, it may never need to be optimized.
+  /// {@endtemplate}
+  ///
+  /// {@macro firefuel.rules.streamcount.footer}
+  @override
+  Stream<int> streamCount() {
+    final snapshots = ref.snapshots();
+
+    return snapshots.map((querySnapshot) => querySnapshot.size);
+  }
+
+  /// {@macro firefuel.rules.streamcountwhere.definition}
+  ///
+  /// {@macro firefuel.collection.streamcount}
+  ///
+  /// {@macro firefuel.rules.streamcountwhere.footer}
+  @override
+  Stream<int> streamCountWhere(List<Clause> clauses) {
+    final snapshots = ref.filter(clauses).snapshots();
+
+    return snapshots.map((querySnapshot) => querySnapshot.size);
   }
 
   @override

--- a/packages/firefuel/lib/src/firefuel_repository.dart
+++ b/packages/firefuel/lib/src/firefuel_repository.dart
@@ -9,6 +9,16 @@ abstract class FirefuelRepository<T extends Serializable>
       : _collection = collection;
 
   @override
+  Future<Either<Failure, int>> count() {
+    return guard(() => _collection.count());
+  }
+
+  @override
+  Future<Either<Failure, int>> countWhere(List<Clause> clauses) {
+    return guard(() => _collection.countWhere(clauses));
+  }
+
+  @override
   Future<Either<Failure, DocumentId>> create(T value) {
     return guard(() => _collection.create(value));
   }
@@ -39,6 +49,16 @@ abstract class FirefuelRepository<T extends Serializable>
   @override
   Stream<Either<Failure, List<T>>> streamAll() {
     return guardStream(() => _collection.streamAll());
+  }
+
+  @override
+  Stream<Either<Failure, int>> streamCount() {
+    return guardStream(() => _collection.streamCount());
+  }
+
+  @override
+  Stream<Either<Failure, int>> streamCountWhere(List<Clause> clauses) {
+    return guardStream(() => _collection.streamCountWhere(clauses));
   }
 
   @override

--- a/packages/firefuel/lib/src/repository.dart
+++ b/packages/firefuel/lib/src/repository.dart
@@ -2,8 +2,8 @@ import 'package:firefuel/firefuel.dart';
 
 abstract class Repository<T extends Serializable>
     implements
+        CollectionCount<Either<Failure, int>>,
         CollectionRead<Either<Failure, List<T>>, T>,
-        CollectionPrimitives<Either<Failure, int>>,
         CollectionPaginate<Either<Failure, Chunk<T>>, T>,
         DocCreate<Either<Failure, DocumentId>, T>,
         DocCreateIfNotExist<Either<Failure, T>, T>,

--- a/packages/firefuel/lib/src/repository.dart
+++ b/packages/firefuel/lib/src/repository.dart
@@ -3,6 +3,7 @@ import 'package:firefuel/firefuel.dart';
 abstract class Repository<T extends Serializable>
     implements
         CollectionRead<Either<Failure, List<T>>, T>,
+        CollectionPrimitives<Either<Failure, int>>,
         CollectionPaginate<Either<Failure, Chunk<T>>, T>,
         DocCreate<Either<Failure, DocumentId>, T>,
         DocCreateIfNotExist<Either<Failure, T>, T>,

--- a/packages/firefuel/lib/src/rules.dart
+++ b/packages/firefuel/lib/src/rules.dart
@@ -23,31 +23,46 @@ abstract class CollectionPaginate<R, T extends Serializable> {
 
 /// Methods used to retrieve primitive values from a collection
 abstract class CollectionPrimitives {
+  /// {@template firefuel.rules.count.definition}
   /// Gets the amount of all documents within the collection.
-  ///
-  /// {@template firefuel.collection.count}
-  /// Uses the count feature introduced in v4.0.0 of `cloud_firestore` to count
-  /// documents on the server without retrieving documents.
-  ///
-  /// > ## Firestore Release Notes
-  /// > Cloud Firestore now supports a count() aggregation query that allows you
-  /// > to determine the number of documents in a collection. The server
-  /// > calculates the count, and transmits only the result, a single integer,
-  /// > back to your app, saving on both billed document reads and bytes
-  /// > transferred, compared to executing the full query.
-  ///
-  /// > Source: https://firebase.google.com/support/releases#firestore-count-queries
   /// {@endtemplate}
   ///
-  /// Related: [countWhere]
+  /// {@template firefuel.rules.count.footer}
+  /// See also: [countWhere]
+  /// {@endtemplate}
   Future<int> count();
 
+  /// {@template firefuel.rules.countwhere.definition}
   /// Gets the amount of documents filtered by the provided clauses.
+  /// {@endtemplate}
   ///
-  /// {@macro firefuel.collection.count}
-  ///
-  /// Related: [count]
+  /// {@template firefuel.rules.countwhere.footer}
+  /// See also: [count]
+  /// {@endtemplate}
   Future<int> countWhere(List<Clause> clauses);
+
+  /// {@template firefuel.rules.streamcount.definition}
+  /// Gets the amount of all documents from the collection
+  ///
+  /// Refreshes automatically when new data is added/removed from the collection
+  /// {@endtemplate}
+  ///
+  /// {@template firefuel.rules.streamcount.footer}
+  /// See also: [streamCountWhere]
+  /// {@endtemplate}
+  Stream<int> streamCount();
+
+  /// {@template firefuel.rules.streamcountwhere.definition}
+  /// Gets the amount of documents from the collection, filtered by the provided
+  /// clauses
+  ///
+  /// Refreshes automatically when new data is added/removed from the collection
+  /// {@endtemplate}
+  ///
+  /// {@template firefuel.rules.streamcountwhere.footer}
+  /// See also: [streamCount]
+  /// {@endtemplate}
+  Stream<int> streamCountWhere(List<Clause> clauses);
 }
 
 /// Read a `List` of [T] from the Collection

--- a/packages/firefuel/lib/src/rules.dart
+++ b/packages/firefuel/lib/src/rules.dart
@@ -22,7 +22,7 @@ abstract class CollectionPaginate<R, T extends Serializable> {
 }
 
 /// Methods used to retrieve primitive values from a collection
-abstract class CollectionPrimitives {
+abstract class CollectionPrimitives<T> {
   /// {@template firefuel.rules.count.definition}
   /// Gets the amount of all documents within the collection.
   /// {@endtemplate}
@@ -30,7 +30,7 @@ abstract class CollectionPrimitives {
   /// {@template firefuel.rules.count.footer}
   /// See also: [countWhere]
   /// {@endtemplate}
-  Future<int> count();
+  Future<T> count();
 
   /// {@template firefuel.rules.countwhere.definition}
   /// Gets the amount of documents filtered by the provided clauses.
@@ -39,7 +39,7 @@ abstract class CollectionPrimitives {
   /// {@template firefuel.rules.countwhere.footer}
   /// See also: [count]
   /// {@endtemplate}
-  Future<int> countWhere(List<Clause> clauses);
+  Future<T> countWhere(List<Clause> clauses);
 
   /// {@template firefuel.rules.streamcount.definition}
   /// Gets the amount of all documents from the collection
@@ -50,7 +50,7 @@ abstract class CollectionPrimitives {
   /// {@template firefuel.rules.streamcount.footer}
   /// See also: [streamCountWhere]
   /// {@endtemplate}
-  Stream<int> streamCount();
+  Stream<T> streamCount();
 
   /// {@template firefuel.rules.streamcountwhere.definition}
   /// Gets the amount of documents from the collection, filtered by the provided
@@ -62,7 +62,7 @@ abstract class CollectionPrimitives {
   /// {@template firefuel.rules.streamcountwhere.footer}
   /// See also: [streamCount]
   /// {@endtemplate}
-  Stream<int> streamCountWhere(List<Clause> clauses);
+  Stream<T> streamCountWhere(List<Clause> clauses);
 }
 
 /// Read a `List` of [T] from the Collection

--- a/packages/firefuel/lib/src/rules.dart
+++ b/packages/firefuel/lib/src/rules.dart
@@ -1,28 +1,7 @@
 import 'package:firefuel/firefuel.dart';
 
-/// Get a number of Documents from the Collection
-///
-/// /// [R]: should return a [T] or some subset,
-/// i.e. `Either<Failure, T>`
-///
-/// {@macro firefuel.rules.subclasses}
-/// {@macro firefuel.rules.implementations}
-abstract class CollectionPaginate<R, T extends Serializable> {
-  /// Get a number of Documents from the Collection specified by the [chunk]
-  ///
-  /// Store the [Chunk] you get back from calling this method and pass it back
-  /// to the [paginate] method to get the next [Chunk]
-  ///
-  /// You can continue to do this until the `Chunk.status` equals
-  /// [ChunkStatus.last].
-  ///
-  /// Passing in a [Chunk] with the status of [ChunkStatus.last] will result in
-  /// a [Chunk] with empty data.
-  Future<R> paginate(Chunk<T> chunk);
-}
-
 /// Methods used to retrieve primitive values from a collection
-abstract class CollectionPrimitives<T> {
+abstract class CollectionCount<T> {
   /// {@template firefuel.rules.count.definition}
   /// Gets the amount of all documents within the collection.
   /// {@endtemplate}
@@ -63,6 +42,27 @@ abstract class CollectionPrimitives<T> {
   /// See also: [streamCount]
   /// {@endtemplate}
   Stream<T> streamCountWhere(List<Clause> clauses);
+}
+
+/// Get a number of Documents from the Collection
+///
+/// /// [R]: should return a [T] or some subset,
+/// i.e. `Either<Failure, T>`
+///
+/// {@macro firefuel.rules.subclasses}
+/// {@macro firefuel.rules.implementations}
+abstract class CollectionPaginate<R, T extends Serializable> {
+  /// Get a number of Documents from the Collection specified by the [chunk]
+  ///
+  /// Store the [Chunk] you get back from calling this method and pass it back
+  /// to the [paginate] method to get the next [Chunk]
+  ///
+  /// You can continue to do this until the `Chunk.status` equals
+  /// [ChunkStatus.last].
+  ///
+  /// Passing in a [Chunk] with the status of [ChunkStatus.last] will result in
+  /// a [Chunk] with empty data.
+  Future<R> paginate(Chunk<T> chunk);
 }
 
 /// Read a `List` of [T] from the Collection

--- a/packages/firefuel/lib/src/rules.dart
+++ b/packages/firefuel/lib/src/rules.dart
@@ -1,5 +1,55 @@
 import 'package:firefuel/firefuel.dart';
 
+/// Get a number of Documents from the Collection
+///
+/// /// [R]: should return a [T] or some subset,
+/// i.e. `Either<Failure, T>`
+///
+/// {@macro firefuel.rules.subclasses}
+/// {@macro firefuel.rules.implementations}
+abstract class CollectionPaginate<R, T extends Serializable> {
+  /// Get a number of Documents from the Collection specified by the [chunk]
+  ///
+  /// Store the [Chunk] you get back from calling this method and pass it back
+  /// to the [paginate] method to get the next [Chunk]
+  ///
+  /// You can continue to do this until the `Chunk.status` equals
+  /// [ChunkStatus.last].
+  ///
+  /// Passing in a [Chunk] with the status of [ChunkStatus.last] will result in
+  /// a [Chunk] with empty data.
+  Future<R> paginate(Chunk<T> chunk);
+}
+
+/// Methods used to retrieve primitive values from a collection
+abstract class CollectionPrimitives {
+  /// Gets the amount of all documents within the collection.
+  ///
+  /// {@template firefuel.collection.count}
+  /// Uses the count feature introduced in v4.0.0 of `cloud_firestore` to count
+  /// documents on the server without retrieving documents.
+  ///
+  /// > ## Firestore Release Notes
+  /// > Cloud Firestore now supports a count() aggregation query that allows you
+  /// > to determine the number of documents in a collection. The server
+  /// > calculates the count, and transmits only the result, a single integer,
+  /// > back to your app, saving on both billed document reads and bytes
+  /// > transferred, compared to executing the full query.
+  ///
+  /// > Source: https://firebase.google.com/support/releases#firestore-count-queries
+  /// {@endtemplate}
+  ///
+  /// Related: [countWhere]
+  Future<int> count();
+
+  /// Gets the amount of documents filtered by the provided clauses.
+  ///
+  /// {@macro firefuel.collection.count}
+  ///
+  /// Related: [count]
+  Future<int> countWhere(List<Clause> clauses);
+}
+
 /// Read a `List` of [T] from the Collection
 ///
 /// [R]: should return a `List<T>` or some subset,
@@ -102,27 +152,6 @@ abstract class CollectionRead<R, T extends Serializable> {
   ///
   /// {@macro firefuel.rules.whereExceptions}
   Future<R> where(List<Clause> clauses, {List<OrderBy>? orderBy, int? limit});
-}
-
-/// Get a number of Documents from the Collection
-///
-/// /// [R]: should return a [T] or some subset,
-/// i.e. `Either<Failure, T>`
-///
-/// {@macro firefuel.rules.subclasses}
-/// {@macro firefuel.rules.implementations}
-abstract class CollectionPaginate<R, T extends Serializable> {
-  /// Get a number of Documents from the Collection specified by the [chunk]
-  ///
-  /// Store the [Chunk] you get back from calling this method and pass it back
-  /// to the [paginate] method to get the next [Chunk]
-  ///
-  /// You can continue to do this until the `Chunk.status` equals
-  /// [ChunkStatus.last].
-  ///
-  /// Passing in a [Chunk] with the status of [ChunkStatus.last] will result in
-  /// a [Chunk] with empty data.
-  Future<R> paginate(Chunk<T> chunk);
 }
 
 /// Create a new Document

--- a/packages/firefuel/pubspec.yaml
+++ b/packages/firefuel/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firefuel
 description: A Firebase Cloud Firestore library to fuel your application's growth!
-version: 0.2.3+1
+version: 0.3.0
 repository: https://github.com/SupposedlySam/firefuel/tree/main/packages/firefuel
 homepage: https://github.com/SupposedlySam/firefuel
 documentation: https://firefuel.dev

--- a/packages/firefuel/test/src/firefuel_collection_test.dart
+++ b/packages/firefuel/test/src/firefuel_collection_test.dart
@@ -26,6 +26,14 @@ void main() {
 
       expect(actual, 3);
     });
+  });
+
+  group('#countWhere', () {
+    setUp(() async {
+      await testCollection.create(defaultUser);
+      await testCollection.create(defaultUser);
+      await testCollection.create(defaultUser);
+    });
 
     test(
       'should return the amount of documents in the collection, filtered by the provided clauses',

--- a/packages/firefuel/test/src/firefuel_collection_test.dart
+++ b/packages/firefuel/test/src/firefuel_collection_test.dart
@@ -14,6 +14,34 @@ void main() {
     testCollection = TestCollection();
   });
 
+  group('#count', () {
+    setUp(() async {
+      await testCollection.create(defaultUser);
+      await testCollection.create(defaultUser);
+      await testCollection.create(defaultUser);
+    });
+
+    test('should return the amount of documents in the collection', () async {
+      final actual = await testCollection.count();
+
+      expect(actual, 3);
+    });
+
+    test(
+      'should return the amount of documents in the collection, filtered by the provided clauses',
+      () async {
+        final newUserName = 'newUser';
+        await testCollection.create(TestUser(newUserName));
+
+        final actual = await testCollection.countWhere([
+          Clause(TestUser.fieldName, isEqualTo: newUserName),
+        ]);
+
+        expect(actual, 1);
+      },
+    );
+  });
+
   group('#create', () {
     test('should return a new document', () async {
       final originalDocId = await testCollection.create(defaultUser);


### PR DESCRIPTION
[Project Card Link]()

### Reason for Change
Adds:
- `count`
- `countWhere`
- `streamCount`
- `streamCountWhere`

### Proposed Changes
Use v4 of `cloud_firestore` to expose access to the new `count` function for `count` and `countWhere`. Provide access to a continually updated count through snapshots.


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


### Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Readme Updated
- [ ] Example project updated
- [x] Tests added/updated
- [x] Changelog updated
- [x] Pubspec version updated
