### PR TITLE
docs: firefuel brick after package release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ flutter_export_environment.sh
 # Flutter Version Manager
 **/.fvm/flutter_sdk
 
+# Mason Code Generator
+.mason
+
 #MacOS related
 **/macos/Flutter/ephemeral/Flutter-Generated.xcconfig
 

--- a/docs/firefuelbrick.md
+++ b/docs/firefuelbrick.md
@@ -18,17 +18,7 @@ For more information on Collections and Repositories, review the [Core Concepts]
 
 ## Using the Firefuel Brick
 
-To install the `firefuel` brick, add (or create) a `mason.yaml` file inside of your Flutter app with the following contents.
-
-```yaml
-bricks:
-  firefuel:
-    git:
-      url: "https://github.com/SupposedlySam/firefuel"
-      path: packages/firefuel/bricks/firefuel
-```
-
-?> **Note** Pending publish on [BrickHub](https://brickhub.dev/bricks/firefuel/0.1.0). If the link above exists, you can install the `firefuel` brick directly from BrickHub using `mason add firefuel`.
+To install the `firefuel` brick, run `mason add firefuel`.
 
 Afterwards, run `mason get` and `mason make firefuel` in the directory you'd like your FirefuelCollection and Model generated.
 

--- a/packages/firefuel/CHANGELOG.md
+++ b/packages/firefuel/CHANGELOG.md
@@ -2,21 +2,11 @@
 
 feat: adds a firefuel brick that can be used through Mason.
 
-To install the `firefuel` brick, add (or create) a `mason.yaml` file inside of your Flutter app with the following contents.
-
-```yaml
-bricks:
-  firefuel:
-    git:
-      url: "https://github.com/SupposedlySam/firefuel"
-      path: packages/firefuel/bricks/firefuel
-```
-
-**note**: Pending publish on [BrickHub](https://brickhub.dev/bricks/firefuel/0.1.0)
+To install the `firefuel` brick, run `mason add firefuel`.
 
 Afterwards, run `mason get` and `mason make firefuel` in the directory you'd like your FirefuelCollection and Model generated.
 
-For more information, see the brick's [README](https://github.com/SupposedlySam/firefuel/blob/main/packages/firefuel/bricks/firefuel/README.md)
+For more information, see the [firefuel brick documentation](https://firefuel.dev/#/firefuelbrick) or refer to the [brick's README](https://github.com/SupposedlySam/firefuel/blob/main/packages/firefuel/bricks/firefuel/README.md)
 
 ## 0.3.1
 

--- a/packages/firefuel/bricks/firefuel/README.md
+++ b/packages/firefuel/bricks/firefuel/README.md
@@ -38,6 +38,8 @@ Whether to create a Repository class to contain your data layer business logic.
 
 i.e. persist data both locally and remote, create a readable name for multiple collection access, etc.
 
+For more information, see [the docs](https://firefuel.dev/#/firefuelbrick)
+
 ---
 
 ## Mason Resources 🧱

--- a/packages/firefuel/bricks/firefuel/brick.yaml
+++ b/packages/firefuel/bricks/firefuel/brick.yaml
@@ -1,5 +1,6 @@
 name: firefuel
 description: Creates a Collection, Model Stub and optional Repository for the firefuel library.
+repository: https://github.com/SupposedlySam/firefuel/tree/main/packages/firefuel/bricks/firefuel
 
 version: 0.1.0
 

--- a/packages/firefuel/mason-lock.json
+++ b/packages/firefuel/mason-lock.json
@@ -1,1 +1,1 @@
-{"bricks":{"firefuel":{"path":"/Users/supposedlysam/development/published_packages/firefuel/packages/firefuel/bricks/firefuel"},"mit_license":"0.1.0+1"}}
+{"bricks":{"firefuel":"0.1.0","mit_license":"0.1.0+1"}}

--- a/packages/firefuel/mason.yaml
+++ b/packages/firefuel/mason.yaml
@@ -1,3 +1,3 @@
 bricks:
-  mit_license: ^0.1.0+1
   firefuel: ^0.1.0
+  mit_license: ^0.1.0+1

--- a/packages/firefuel/mason.yaml
+++ b/packages/firefuel/mason.yaml
@@ -1,4 +1,3 @@
 bricks:
-  firefuel:
-    path: ./bricks/firefuel
   mit_license: ^0.1.0+1
+  firefuel: ^0.1.0


### PR DESCRIPTION
### Reason for Change
Docs need to be updated to show how to get the firefuel brick from BrickHub

### Proposed Changes
Update readme and docs to reflect changes of getting the firefuel brick via `mason add firefuel` instead of through a git url.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore


### Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] Readme Updated
- [ ] Example project updated
- [ ] Tests added/updated
- [x] Changelog updated
- [ ] Pubspec version updated
