### PR TITLE
refactor!: rename count methods for consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ flutter_export_environment.sh
 # Flutter Version Manager
 **/.fvm/flutter_sdk
 
+# Very Good CLI
+**/.test_runner.dart
+
 # Mason Code Generator
 .mason
 

--- a/packages/firefuel/CHANGELOG.md
+++ b/packages/firefuel/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.4.0
+
+refactor!: renames `count` and `streamCount` to `countAll` and `streamCountAll`
+
+This change was made to be more explicit, aligns with other methods such as `readAll` and `streamAll`, and leads us to look for other options like `countWhere` and `streamCountWhere` when using it in our apps.
+
+BREAKING:
+
+- `count` is now `countAll`
+- `streamCount` is now `streamCountAll`
+
 ## 0.3.2
 
 feat: adds a firefuel brick that can be used through Mason.

--- a/packages/firefuel/example/packages/firefuel_counter/pubspec.lock
+++ b/packages/firefuel/example/packages/firefuel_counter/pubspec.lock
@@ -135,7 +135,7 @@ packages:
       path: "../../.."
       relative: true
     source: path
-    version: "0.3.1"
+    version: "0.4.0"
   firefuel_core:
     dependency: transitive
     description:

--- a/packages/firefuel/example/pubspec.lock
+++ b/packages/firefuel/example/pubspec.lock
@@ -223,7 +223,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.2"
+    version: "0.4.0"
   firefuel_core:
     dependency: transitive
     description:

--- a/packages/firefuel/lib/src/firefuel_collection.dart
+++ b/packages/firefuel/lib/src/firefuel_collection.dart
@@ -5,7 +5,6 @@ import 'package:firefuel/src/utils/serializable_extensions.dart';
 
 abstract class FirefuelCollection<T extends Serializable>
     implements Collection<T> {
-
   FirefuelCollection(String path, {bool useEnv = true})
       : path = _buildPath(path, useEnv);
   final String path;
@@ -42,7 +41,7 @@ abstract class FirefuelCollection<T extends Serializable>
   ///
   /// {@macro firefuel.rules.count.footer}
   @override
-  Future<int> count() async {
+  Future<int> countAll() async {
     final snapshot = await untypedRef.count().get();
 
     return snapshot.count;
@@ -209,7 +208,7 @@ abstract class FirefuelCollection<T extends Serializable>
   /// This method DOES NOT use the server side count function provided by
   /// v4.0.0 of `cloud_firestore` as they do not currenly support streams.
   ///
-  /// See [count] and [countWhere] for more details.
+  /// See [countAll] and [countWhere] for more details.
   ///
   /// This method works by streaming documents from Firestore and accessing the
   /// size property once the full query is executed. This method will incur
@@ -222,7 +221,7 @@ abstract class FirefuelCollection<T extends Serializable>
   ///
   /// {@macro firefuel.rules.streamcount.footer}
   @override
-  Stream<int> streamCount() {
+  Stream<int> streamCountAll() {
     final snapshots = ref.snapshots();
 
     return snapshots.map((querySnapshot) => querySnapshot.size);

--- a/packages/firefuel/lib/src/firefuel_repository.dart
+++ b/packages/firefuel/lib/src/firefuel_repository.dart
@@ -3,14 +3,13 @@ import 'package:firefuel/firefuel.dart';
 abstract class FirefuelRepository<T extends Serializable>
     with FirefuelFetchMixin
     implements Repository<T> {
-
   const FirefuelRepository({required Collection<T> collection})
       : _collection = collection;
   final Collection<T> _collection;
 
   @override
-  Future<Either<Failure, int>> count() {
-    return guard(_collection.count);
+  Future<Either<Failure, int>> countAll() {
+    return guard(_collection.countAll);
   }
 
   @override
@@ -52,8 +51,8 @@ abstract class FirefuelRepository<T extends Serializable>
   }
 
   @override
-  Stream<Either<Failure, int>> streamCount() {
-    return guardStream(_collection.streamCount);
+  Stream<Either<Failure, int>> streamCountAll() {
+    return guardStream(_collection.streamCountAll);
   }
 
   @override

--- a/packages/firefuel/lib/src/rules.dart
+++ b/packages/firefuel/lib/src/rules.dart
@@ -9,14 +9,14 @@ abstract class CollectionCount<T> {
   /// {@template firefuel.rules.count.footer}
   /// See also: [countWhere]
   /// {@endtemplate}
-  Future<T> count();
+  Future<T> countAll();
 
   /// {@template firefuel.rules.countwhere.definition}
   /// Gets the amount of documents filtered by the provided clauses.
   /// {@endtemplate}
   ///
   /// {@template firefuel.rules.countwhere.footer}
-  /// See also: [count]
+  /// See also: [countAll]
   /// {@endtemplate}
   Future<T> countWhere(List<Clause> clauses);
 
@@ -29,7 +29,7 @@ abstract class CollectionCount<T> {
   /// {@template firefuel.rules.streamcount.footer}
   /// See also: [streamCountWhere]
   /// {@endtemplate}
-  Stream<T> streamCount();
+  Stream<T> streamCountAll();
 
   /// {@template firefuel.rules.streamcountwhere.definition}
   /// Gets the amount of documents from the collection, filtered by the provided
@@ -39,7 +39,7 @@ abstract class CollectionCount<T> {
   /// {@endtemplate}
   ///
   /// {@template firefuel.rules.streamcountwhere.footer}
-  /// See also: [streamCount]
+  /// See also: [streamCountAll]
   /// {@endtemplate}
   Stream<T> streamCountWhere(List<Clause> clauses);
 }

--- a/packages/firefuel/pubspec.yaml
+++ b/packages/firefuel/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firefuel
 description: A Firebase Cloud Firestore library to fuel your application's growth!
-version: 0.3.2+1
+version: 0.4.0
 repository: https://github.com/SupposedlySam/firefuel/tree/main/packages/firefuel
 homepage: https://github.com/SupposedlySam/firefuel
 documentation: https://firefuel.dev

--- a/packages/firefuel/test/src/firefuel_collection_test.dart
+++ b/packages/firefuel/test/src/firefuel_collection_test.dart
@@ -16,7 +16,7 @@ void main() {
 
   tearDown(Firefuel.reset);
 
-  group('#count', () {
+  group('#countAll', () {
     setUp(() async {
       await testCollection.create(defaultUser);
       await testCollection.create(defaultUser);
@@ -24,7 +24,7 @@ void main() {
     });
 
     test('should return the amount of documents in the collection', () async {
-      final actual = await testCollection.count();
+      final actual = await testCollection.countAll();
 
       expect(actual, 3);
     });
@@ -237,14 +237,14 @@ void main() {
     });
   });
 
-  group('#streamCount', () {
+  group('#streamCountAll', () {
     late Stream<int> stream;
     late DocumentId docId;
 
     setUp(() async {
       docId = await testCollection.create(defaultUser);
 
-      stream = testCollection.streamCount();
+      stream = testCollection.streamCountAll();
     });
 
     test('should output new value when new doc is created', () async {


### PR DESCRIPTION
### Reason for Change
refactor!: renames `count` and `streamCount` to `countAll` and `streamCountAll`

Be more explicit, aligns with other methods such as `readAll` and `streamAll`, and leads us to look for other options like `countWhere` and `streamCountWhere` when using it in our apps.

### Proposed Changes
Rename `count` and `streamCount` to `countAll` and `streamCountAll`


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


### Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Readme Updated
- [ ] Example project updated
- [x] Tests added/updated
- [x] Changelog updated
- [x] Pubspec version updated
